### PR TITLE
feat: implement tabular list view for interests page

### DIFF
--- a/src/components/ui/InterestPetCard.tsx
+++ b/src/components/ui/InterestPetCard.tsx
@@ -12,124 +12,154 @@ export interface Pet {
     adoption: boolean;
 }
 
-interface PetCardProps {
-    pet: Pet;
-    onToggleInterested: (id: string) => void;
+type InterestStatus = "awaiting" | "granted" | "in-progress";
+
+function getInterestStatus(pet: Pet): InterestStatus {
+    if (pet.consent === "awaiting") return "awaiting";
+    if (pet.consent === "granted" && !pet.adoption) return "granted";
+    return "in-progress";
 }
 
-export function InterestPetCard({ pet, onToggleInterested }: PetCardProps) {
+const STATUS_MAP: Record<
+    InterestStatus,
+    { label: string; textClass: string; bgClass: string; dotClass: string }
+> = {
+    awaiting: {
+        label: "Awaiting Consent",
+        textClass: "text-[#D97706]",
+        bgClass: "bg-[#FFFBEB]",
+        dotClass: "bg-[#F3A534]",
+    },
+    granted: {
+        label: "Consent Granted",
+        textClass: "text-[#16A34A]",
+        bgClass: "bg-[#F0FDF4]",
+        dotClass: "bg-[#22C55E]",
+    },
+    "in-progress": {
+        label: "Adoption In-Progress",
+        textClass: "text-[#2563EB]",
+        bgClass: "bg-[#EFF6FF]",
+        dotClass: "bg-[#285CE0]",
+    },
+};
+
+interface InterestPetCardProps {
+    pet: Pet;
+    onRemove: (id: string) => void;
+    onViewDetails: (id: string) => void;
+    onStartAdoption: (id: string) => void;
+    onConfirmCompletion: (id: string) => void;
+}
+
+export function InterestPetCard({
+    pet,
+    onRemove,
+    onViewDetails,
+    onStartAdoption,
+    onConfirmCompletion,
+}: InterestPetCardProps) {
+    const status = getInterestStatus(pet);
+    const { label, textClass, bgClass, dotClass } = STATUS_MAP[status];
+
     return (
-        <div className="flex flex-col bg-white rounded-[20px] overflow-hidden border border-gray-100 shadow-sm transition-transform hover:-translate-y-1 hover:shadow-md">
-            {/* Image container with aspect ratio */}
-            <div className="relative w-full pb-[85%] bg-gray-100 overflow-hidden group">
-                <img
-                    src={pet.imageUrl}
-                    alt={pet.name}
-                    className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-                />
-
-                {/* Action Buttons Container */}
-                <div className="absolute top-4 right-4 flex flex-col gap-2">
-                    {/* Interested (+) Button */}
-                    <button
-                        onClick={() => onToggleInterested(pet.id)}
-                        className={`w-10 h-10 rounded-full flex items-center justify-center shadow-lg transition-colors active:scale-90 ${pet.isInterested ? "bg-[#0D1B2A] text-white" : "bg-[#FF4726] text-white hover:bg-gray-50"
-                            }`}
-                        aria-label={pet.isInterested ? "Remove interest" : "Mark as interested"}
-                    >
-                        {pet.isInterested ? (
-                            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                            </svg>
-                        ) : (
-                            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                            </svg>
-                        )}
-                    </button>
+        <div className="grid grid-cols-1 lg:grid-cols-[2fr_1.2fr_1.2fr_1.5fr] items-center gap-4 lg:gap-6 bg-white rounded-2xl border border-gray-100 p-4 lg:px-6 lg:py-4 shadow-sm hover:shadow-md transition-shadow">
+            <div className="flex items-center gap-4">
+                <div className="w-14 h-14 rounded-xl overflow-hidden bg-gray-100 shrink-0">
+                    <img
+                        src={pet.imageUrl}
+                        alt={pet.name}
+                        className="w-full h-full object-cover"
+                    />
                 </div>
-
-                {/* User avatar mockup overlay */}
-                <div className="absolute top-[84px] right-4">
-                    <div className="w-10 h-10 rounded-full bg-white p-[2px] shadow-sm">
-                        <img src="/src/assets/owner.png" alt="Lister" className="w-full h-full rounded-full bg-[#0D1B2A] object-contain p-1" />
-                    </div>
-                </div>
-
-                {/* Banners & Actions Container */}
-                <div className="absolute bottom-3 left-3 right-3 flex flex-col gap-2">
-                    {pet.consent === "awaiting" && (
-                        <div className="w-full bg-white rounded-[10px] flex items-center justify-between px-4 py-3 shadow-md">
-                            <div className="flex items-center gap-3">
-                                <svg className="w-[20px] h-[20px] text-[#F3A534]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                                <span className="text-[#0D1B2A] font-semibold text-[14px]">Awaiting Consent</span>
-                            </div>
-                            <svg className="w-5 h-5 text-[#0D1B2A]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                        </div>
-                    )}
-
-                    {pet.consent === "granted" && !pet.adoption && (
-                        <div className="w-full bg-white rounded-[10px] flex items-center justify-between px-4 py-3 shadow-md">
-                            <div className="flex items-center gap-3">
-                                <svg className="w-[20px] h-[20px] text-[#22C55E]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                                </svg>
-                                <span className="text-[#0D1B2A] font-semibold text-[14px]">Consent Granted</span>
-                            </div>
-                            <svg className="w-5 h-5 text-[#0D1B2A]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                        </div>
-                    )}
-
-                    {pet.consent === "granted" && pet.adoption && (
-                        <div className="w-full bg-white rounded-[10px] flex items-center justify-between px-4 py-3 shadow-md">
-                            <div className="flex items-center gap-3">
-                                <svg className="w-[20px] h-[20px] text-[#285CE0]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                                <span className="text-[#0D1B2A] font-semibold text-[14px]">Adoption In-Progress</span>
-                            </div>
-                            <svg className="w-5 h-5 text-[#0D1B2A]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                        </div>
-                    )}
-
-                    {pet.consent === "granted" && !pet.adoption && (
-                        <button className="w-full bg-[#FF4726] text-white py-[14px] rounded-xl font-semibold text-[14px] hover:bg-[#E84D2A] transition-colors flex items-center justify-center gap-2">
-                            <span>Start Adoption Process</span>
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-                            </svg>
-                        </button>
-                    )}
-                    {pet.consent === "granted" && pet.adoption && (
-                        <button className="w-full bg-[#E8E6F5] text-[#0D1B2A] py-[14px] rounded-xl font-semibold text-[14px] hover:bg-[#16A34A] transition-colors">
-                            Confirmed Pet Recieved
-                        </button>
-                    )}
+                <div className="min-w-0">
+                    <h3 className="text-[15px] font-bold text-[#0D162B] truncate">
+                        {pet.name}
+                    </h3>
+                    <p className="text-[13px] text-gray-500 font-medium truncate">
+                        {pet.breed}, {pet.age}
+                    </p>
                 </div>
             </div>
 
-            {/* Content Area */}
-            <div className="p-5 flex flex-col gap-1">
-                <h3 className="text-lg font-bold text-[#0D162B]">{pet.name}</h3>
-                <p className="text-[13px] text-gray-500 font-medium">
-                    {pet.breed}, {pet.age}
-                </p>
+            <div className="flex items-center gap-1.5 text-gray-500">
+                <svg
+                    className="w-[14px] h-[14px] shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                    />
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                </svg>
+                <span className="text-[13px] font-medium truncate">
+                    {pet.location}
+                </span>
+            </div>
 
-                <div className="flex items-center gap-1.5 mt-3 text-gray-500">
-                    <svg className="w-[14px] h-[14px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            <div>
+                <span
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold ${textClass} ${bgClass}`}
+                >
+                    <span className={`w-1.5 h-1.5 rounded-full ${dotClass}`} />
+                    {label}
+                </span>
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap lg:flex-nowrap">
+                <button
+                    onClick={() => onViewDetails(pet.id)}
+                    className="px-4 py-2 text-[13px] font-semibold text-[#0D162B] bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                    View Details
+                </button>
+
+                {status === "granted" && (
+                    <button
+                        onClick={() => onStartAdoption(pet.id)}
+                        className="px-4 py-2 text-[13px] font-semibold text-white bg-[#E84D2A] rounded-lg hover:bg-[#d4431f] transition-colors whitespace-nowrap"
+                    >
+                        Start Adoption
+                    </button>
+                )}
+
+                {status === "in-progress" && (
+                    <button
+                        onClick={() => onConfirmCompletion(pet.id)}
+                        className="px-4 py-2 text-[13px] font-semibold text-white bg-[#0D1B2A] rounded-lg hover:bg-gray-900 transition-colors whitespace-nowrap"
+                    >
+                        Confirm Completion
+                    </button>
+                )}
+
+                <button
+                    onClick={() => onRemove(pet.id)}
+                    className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                    aria-label="Remove from interests"
+                >
+                    <svg
+                        className="w-[18px] h-[18px]"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                    >
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
                     </svg>
-                    <span className="text-[12px] font-medium">{pet.location}</span>
-                </div>
+                </button>
             </div>
         </div>
     );

--- a/src/pages/interestPage.tsx
+++ b/src/pages/interestPage.tsx
@@ -1,13 +1,11 @@
 import { useState, useMemo } from "react";
 import { FormSelect } from "../components/ui/formSelect";
+import { InterestPetCard, type Pet } from "../components/ui/InterestPetCard";
 
-// Import images provided by user
 import dogImg from "../assets/dog.png";
 import parrotImg from "../assets/parrot.png";
 import catImg from "../assets/cat.png";
-import { InterestPetCard, type Pet } from "../components/ui/InterestPetCard";
 
-// Mock Data
 const MOCK_PETS: Pet[] = [
     {
         id: "1",
@@ -17,8 +15,8 @@ const MOCK_PETS: Pet[] = [
         age: "4yrs old",
         location: "Mainland, Lagos Nigeria",
         imageUrl: dogImg,
-        isFavourite: true,
-        isInterested: false,
+        isFavourite: false,
+        isInterested: true,
         consent: "awaiting",
         adoption: false,
     },
@@ -30,8 +28,8 @@ const MOCK_PETS: Pet[] = [
         age: "4yrs old",
         location: "Mainland, Lagos Nigeria",
         imageUrl: parrotImg,
-        isFavourite: true,
-        isInterested: false,
+        isFavourite: false,
+        isInterested: true,
         consent: "granted",
         adoption: false,
     },
@@ -43,8 +41,8 @@ const MOCK_PETS: Pet[] = [
         age: "4yrs old",
         location: "Mainland, Lagos Nigeria",
         imageUrl: catImg,
-        isFavourite: true,
-        isInterested: false,
+        isFavourite: false,
+        isInterested: true,
         consent: "granted",
         adoption: true,
     },
@@ -62,17 +60,13 @@ export default function InterestPage() {
     const [locationFilter, setLocationFilter] = useState("");
     const [categoryFilter, setCategoryFilter] = useState("all");
 
-    // Filter Logic
     const filteredPets = useMemo(() => {
         return pets.filter((pet) => {
-            // 1. Must be a favourite to show on this page
-            if (!pet.isFavourite) return false;
+            if (!pet.isInterested) return false;
 
-            // 2. Category Filter
             const matchesCategory =
                 categoryFilter === "all" || pet.category === categoryFilter;
 
-            // 3. Location Filter (simple substring check)
             const matchesLocation =
                 locationFilter === "" ||
                 pet.location.toLowerCase().includes(locationFilter.toLowerCase());
@@ -81,12 +75,28 @@ export default function InterestPage() {
         });
     }, [pets, locationFilter, categoryFilter]);
 
-    const handleToggleInterested = (id: string) => {
+    const handleRemove = (id: string) => {
         setPets((prev) =>
             prev.map((p) =>
-                p.id === id ? { ...p, isInterested: !p.isInterested } : p
+                p.id === id ? { ...p, isInterested: false } : p
             )
         );
+    };
+
+    const handleViewDetails = (_id: string) => {
+        // placeholder for navigation to listing detail page
+    };
+
+    const handleStartAdoption = (id: string) => {
+        setPets((prev) =>
+            prev.map((p) =>
+                p.id === id ? { ...p, adoption: true } : p
+            )
+        );
+    };
+
+    const handleConfirmCompletion = (_id: string) => {
+        // placeholder for adoption confirmation flow
     };
 
     const handleResetFilters = () => {
@@ -96,24 +106,34 @@ export default function InterestPage() {
 
     return (
         <div className="min-h-screen bg-[#F9FAFB] pb-24">
-            {/* ── Navbar Placeholder ── */}
             <div className="bg-white border-b border-gray-100 h-20 mb-8" />
 
             <div className="max-w-[1240px] mx-auto px-6 lg:px-8">
-
-                {/* Page Header & Filters */}
                 <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
                     <h1 className="text-[22px] font-bold text-[#0D162B]">
                         Interest ({filteredPets.length})
                     </h1>
 
                     <div className="flex flex-wrap items-center gap-3">
-                        {/* Location Filter */}
                         <div className="relative w-full sm:w-[220px]">
                             <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
-                                <svg className="w-[18px] h-[18px] text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                                <svg
+                                    className="w-[18px] h-[18px] text-gray-400"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                                    />
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                                    />
                                 </svg>
                             </div>
                             <input
@@ -125,7 +145,6 @@ export default function InterestPage() {
                             />
                         </div>
 
-                        {/* Category Filter */}
                         <div className="w-[160px] relative">
                             <FormSelect
                                 id="category-filter"
@@ -133,57 +152,89 @@ export default function InterestPage() {
                                 options={CATEGORY_OPTIONS}
                                 value={categoryFilter}
                                 onChange={(e) => setCategoryFilter(e.target.value)}
-                                className="!py-2.5" // Override py padding to match inputs
+                                className="!py-2.5"
                             />
-                            {/* Adjust styling of FormSelect specifically for this context to look like the design */}
                         </div>
 
-                        {/* Reset Button */}
                         <button
                             onClick={handleResetFilters}
                             className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-gray-100 text-gray-600 font-medium text-[14px] hover:bg-gray-200 transition-colors"
                         >
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            <svg
+                                className="w-4 h-4"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={2}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                                />
                             </svg>
                             Reset
                         </button>
                     </div>
                 </div>
 
-                {/* Pet Grid */}
                 {filteredPets.length > 0 ? (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                        {filteredPets.map((pet) => (
-                            <InterestPetCard
-                                key={pet.id}
-                                pet={pet}
-                                onToggleInterested={handleToggleInterested}
-                            />
-                        ))}
+                    <div>
+                        <div className="hidden lg:grid grid-cols-[2fr_1.2fr_1.2fr_1.5fr] gap-6 px-6 pb-3 text-[12px] font-semibold text-gray-400 uppercase tracking-wider">
+                            <span>Pet Details</span>
+                            <span>Location</span>
+                            <span>Status</span>
+                            <span>Actions</span>
+                        </div>
+
+                        <div className="flex flex-col gap-3">
+                            {filteredPets.map((pet) => (
+                                <InterestPetCard
+                                    key={pet.id}
+                                    pet={pet}
+                                    onRemove={handleRemove}
+                                    onViewDetails={handleViewDetails}
+                                    onStartAdoption={handleStartAdoption}
+                                    onConfirmCompletion={handleConfirmCompletion}
+                                />
+                            ))}
+                        </div>
                     </div>
                 ) : (
-                    /* Empty State */
                     <div className="flex flex-col items-center justify-center py-32 text-center bg-white rounded-2xl border border-gray-100">
                         <div className="w-20 h-20 bg-gray-50 rounded-full flex items-center justify-center mb-4">
-                            <svg className="w-10 h-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                            <svg
+                                className="w-10 h-10 text-gray-300"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                                strokeWidth={1.5}
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                                />
                             </svg>
                         </div>
-                        <h3 className="text-xl font-bold text-gray-900 mb-2">No favourites found</h3>
+                        <h3 className="text-xl font-bold text-gray-900 mb-2">
+                            No interests found
+                        </h3>
                         <p className="text-gray-500 max-w-[300px]">
-                            {pets.filter(p => p.isFavourite).length > 0
+                            {pets.filter((p) => p.isInterested).length > 0
                                 ? "No pets match your current filter criteria. Try resetting the filters."
-                                : "You haven't added any pets to your favourites list yet!"}
+                                : "You haven't expressed interest in adopting any pets yet."}
                         </p>
-                        {pets.filter(p => p.isFavourite).length > 0 && (
-                            <button onClick={handleResetFilters} className="mt-6 text-[#E84D2A] font-medium hover:underline">
+                        {pets.filter((p) => p.isInterested).length > 0 && (
+                            <button
+                                onClick={handleResetFilters}
+                                className="mt-6 text-[#E84D2A] font-medium hover:underline"
+                            >
                                 Clear Filters
                             </button>
                         )}
                     </div>
                 )}
-
             </div>
         </div>
     );


### PR DESCRIPTION
Refactor the interests page from a card grid layout to a tabular list view showing pets a user has marked as interested in adopting.

- Replace card grid with responsive table layout (columns: Pet Details, Location, Status, Actions)
- Add column headers visible on desktop breakpoint
- Display status badges: Awaiting Consent, Consent Granted, Adoption In-Progress with color-coded indicators
- Add CTA buttons: View Details, Start Adoption, Confirm Completion, and Remove from Interests
- Update InterestPetCard component to render as a table row
- Fix filter logic to use isInterested instead of isFavourite
- Responsive design: stacks to single column on mobile

Closes #66