### PR TITLE
feat: add ModalPreview route and enhance UI components in Adoption an…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { AdoptionCompletionDemo } from "./pages/AdoptionCompletionDemo";
 import PetListingDetailsPage from "./pages/PetlistingdetailsPage";
 import EditAdoptionListing from "./pages/EditAdoptionListing";
 import ListingDetailsPage from "./pages/ListingDetailsPage";
+import ModalPreview from "./pages/ModalPreview";
 
 function App() {
   return (
@@ -32,18 +33,14 @@ function App() {
         <Route path="/favourites" element={<FavouritePage />} />
         <Route path="/interests" element={<InterestPage />} />
         <Route path="/listings" element={<ListingsPage />} />
+        <Route path="/listings/:id" element={<PetListingDetailsPage />} />
+        <Route path="/list-for-adoption" element={<EditAdoptionListing />} />
+        <Route path="/my-listings/:id" element={<ListingDetailsPage />} />
         <Route path="/notifications" element={<NotificationPage />} />
 
         {/* Preview Routes */}
         <Route path="/preview-modal" element={<ModalPreview />} />
         <Route path="/adoption-completion-demo" element={<AdoptionCompletionDemo />} />
-
-        {/* Test Route */}
-      </Routes>
-    </BrowserRouter>
-        <Route path="/listings/:id" element={<PetListingDetailsPage />} />
-        <Route path="/list-for-adoption" element={<EditAdoptionListing />} />
-        <Route path="/my-listings/:id" element={<ListingDetailsPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/ui/AdoptionDetailsModal.tsx
+++ b/src/components/ui/AdoptionDetailsModal.tsx
@@ -38,102 +38,104 @@ export function AdoptionDetailsModal({
     data,
     onListerClick,
 }: AdoptionDetailsModalProps) {
+    const [activeTab, setActiveTab] = useState<AdoptionTab>("pet");
+
     if (!isOpen) return null;
     if (!data) return null;
-
-    const [activeTab, setActiveTab] = useState<AdoptionTab>("pet");
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
             <div
-                className="w-full max-w-[500px] bg-white rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
+                className="w-full max-w-[500px] bg-white rounded-xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="adoption-details-title"
             >
-                <div className="flex items-center justify-between p-6 border-b border-gray-100 shrink-0">
-                    <h2 id="adoption-details-title" className="text-xl font-semibold text-[#0D162B]">
+                <div className="flex items-center justify-between px-9 pt-9 pb-6 shrink-0">
+                    <h2 id="adoption-details-title" className="text-[36px] leading-[1.2] font-semibold text-[#0F2236]">
                         Adoption Details
                     </h2>
                     <button
                         onClick={onClose}
-                        className="p-2 -mr-2 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors"
+                        className="p-1 -mr-1 text-[#98A2B3] hover:text-[#667085] transition-colors"
                         aria-label="Close"
                     >
-                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.9} stroke="currentColor">
                             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
                 </div>
 
-                <div className="flex border-b border-gray-200">
+                <div className="px-9">
+                    <div className="flex border border-[#E4E7EC] overflow-hidden rounded-[2px]">
                     {(["pet", "receipt", "lister"] as const).map((tab) => (
                         <button
                             key={tab}
                             onClick={() => setActiveTab(tab)}
-                            className={`flex-1 px-4 py-3 text-[13px] font-semibold transition-colors ${
+                            className={`flex-1 px-4 py-3 text-[14px] leading-6  border-r border-[#E4E7EC] last:border-r-0 transition-colors ${
                                 activeTab === tab
-                                    ? "text-[#0D162B] border-b-2 border-[#0D162B] bg-gray-50/50"
-                                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-50/50"
+                                    ? "text-[#0F2236] bg-[#EAEAEA] font-medium"
+                                    : "text-[#667085] bg-white hover:bg-[#F9FAFB] font-medium"
                             }`}
                         >
                             {tab === "pet" && "Pet Details"}
-                            {tab === "receipt" && "Receipt Details"}
+                            {tab === "receipt" && "Receipts Details"}
                             {tab === "lister" && "Lister's Details"}
                         </button>
                     ))}
+                    </div>
                 </div>
 
-                <div className="flex-1 overflow-y-auto p-6 scrollbar-minimal">
+                <div className="flex-1 overflow-y-auto px-9 pt-8 pb-9 scrollbar-minimal">
                     {activeTab === "pet" && (
-                        <div className="flex flex-col items-center">
-                            <div className="w-24 h-24 rounded-full overflow-hidden border-2 border-gray-100 mb-6">
+                        <div>
+                            <div className="w-[128px] h-[128px] rounded-xl overflow-hidden border border-[#E4E7EC] mb-6">
                                 <img
                                     src={data.pet.imageUrl}
                                     alt={data.pet.name}
                                     className="w-full h-full object-cover"
                                 />
                             </div>
-                            <div className="w-full space-y-3 text-left">
-                                <Row label="Pet Type" value={data.pet.petType} />
-                                <Row label="Breed" value={data.pet.breed} />
-                                <Row label="Age" value={data.pet.age} />
-                                <Row label="Gender" value={data.pet.gender} />
-                                <Row label="Vaccinated Status" value={data.pet.vaccinated} />
+                            <div className="w-full">
+                                <InlineRow label="Pet Type" value={data.pet.petType} />
+                                <InlineRow label="Breed" value={data.pet.breed} />
+                                <InlineRow label="Age" value={data.pet.age} />
+                                <InlineRow label="Gender" value={data.pet.gender} />
+                                <InlineRow label="Vaccinated Status" value={data.pet.vaccinated} isLast />
                             </div>
                         </div>
                     )}
                     {activeTab === "receipt" && (
-                        <div className="space-y-3">
-                            <Row label="Date Received" value={data.receipt.dateReceived} />
-                            <Row label="Receipt Location / Address" value={data.receipt.receiptAddress} />
-                            <Row label="Pet Condition" value={data.receipt.petCondition} />
+                        <div className="pt-2">
+                            <InlineRow label="Date Received" value={data.receipt.dateReceived} />
+                            <InlineRow label="Receipt Location / Address" value={data.receipt.receiptAddress} />
+                            <InlineRow label="Pet Condition" value={data.receipt.petCondition} isLast />
                         </div>
                     )}
                     {activeTab === "lister" && (
-                        <div className="flex flex-col items-center">
-                            <div className="w-20 h-20 rounded-full overflow-hidden border-2 border-gray-100 mb-4">
+                        <div>
+                            <div className="w-[122px] h-[122px] rounded-xl overflow-hidden border border-[#E4E7EC] mb-6">
                                 <img
                                     src={data.lister.imageUrl}
                                     alt={data.lister.fullName}
                                     className="w-full h-full object-cover"
                                 />
                             </div>
-                            <div className="w-full space-y-3 text-left">
-                                <Row label="Full Name" value={data.lister.fullName} />
+                            <div className="w-full">
+                                <InlineRow label="Full Name" value={data.lister.fullName} />
                                 {data.lister.profileId && onListerClick ? (
-                                    <div className="py-2">
-                                        <p className="text-[13px] text-gray-400 mb-1">Location</p>
+                                    <div className="grid grid-cols-[1fr_1.7fr] items-center py-3 border-b border-[#EAECF0]">
+                                        <p className="text-[15px] leading-6 text-[#667085]">Location:</p>
                                         <button
                                             type="button"
                                             onClick={() => onListerClick(data.lister.profileId!)}
-                                            className="text-[15px] font-semibold text-[#0D162B] hover:text-[#E84D2A] underline underline-offset-2"
+                                            className="text-left text-[15px] leading-6 font-semibold text-[#0F2236] hover:text-[#0F2236]"
                                         >
                                             {data.lister.location}
                                         </button>
                                     </div>
                                 ) : (
-                                    <Row label="Location" value={data.lister.location} />
+                                    <InlineRow label="Location" value={data.lister.location} isLast />
                                 )}
                             </div>
                         </div>
@@ -144,11 +146,19 @@ export function AdoptionDetailsModal({
     );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function InlineRow({
+    label,
+    value,
+    isLast = false,
+}: {
+    label: string;
+    value: string;
+    isLast?: boolean;
+}) {
     return (
-        <div className="py-2 border-b border-gray-100 last:border-0">
-            <p className="text-[13px] text-gray-400 mb-0.5">{label}</p>
-            <p className="text-[15px] font-semibold text-[#0D162B]">{value}</p>
+        <div className={`grid grid-cols-[1fr_1.7fr] items-center py-3 ${isLast ? "" : "border-b border-[#EAECF0]"}`}>
+            <p className="text-[15px] leading-6 text-[#667085]">{label}:</p>
+            <p className="text-[15px] leading-6 font-semibold text-[#0F2236]">{value}</p>
         </div>
     );
 }

--- a/src/components/ui/ListingDetailsModal.tsx
+++ b/src/components/ui/ListingDetailsModal.tsx
@@ -37,101 +37,103 @@ export function ListingDetailsModal({
     data,
     onAdopterClick,
 }: ListingDetailsModalProps) {
+    const [activeTab, setActiveTab] = useState<ListingTab>("pet");
+
     if (!isOpen) return null;
     if (!data) return null;
-
-    const [activeTab, setActiveTab] = useState<ListingTab>("pet");
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
             <div
-                className="w-full max-w-[500px] bg-white rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
+                className="w-full max-w-[500px] bg-white rounded-xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="listing-details-title"
             >
-                <div className="flex items-center justify-between p-6 border-b border-gray-100 shrink-0">
-                    <h2 id="listing-details-title" className="text-xl font-semibold text-[#0D162B]">
-                        Listing Details
+                <div className="flex items-center justify-between px-9 pt-9 pb-6 shrink-0">
+                    <h2 id="listing-details-title" className="text-[36px] leading-[1.2] font-semibold text-[#0F2236]">
+                        Adoption Details
                     </h2>
                     <button
                         onClick={onClose}
-                        className="p-2 -mr-2 text-gray-400 hover:text-gray-600 rounded-full hover:bg-gray-100 transition-colors"
+                        className="p-1 -mr-1 text-[#98A2B3] hover:text-[#667085] transition-colors"
                         aria-label="Close"
                     >
-                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                        <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" strokeWidth={1.9} stroke="currentColor">
                             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                         </svg>
                     </button>
                 </div>
 
-                <div className="flex border-b border-gray-200">
-                    {(["pet", "transfer", "adopter"] as const).map((tab) => (
-                        <button
-                            key={tab}
-                            onClick={() => setActiveTab(tab)}
-                            className={`flex-1 px-4 py-3 text-[13px] font-semibold transition-colors ${
-                                activeTab === tab
-                                    ? "text-[#0D162B] border-b-2 border-[#0D162B] bg-gray-50/50"
-                                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-50/50"
-                            }`}
-                        >
-                            {tab === "pet" && "Pet Details"}
-                            {tab === "transfer" && "Transfer Details"}
-                            {tab === "adopter" && "Adopter's Details"}
-                        </button>
-                    ))}
+                <div className="px-9">
+                    <div className="flex border border-[#E4E7EC] overflow-hidden rounded-[2px]">
+                        {(["pet", "transfer", "adopter"] as const).map((tab) => (
+                            <button
+                                key={tab}
+                                onClick={() => setActiveTab(tab)}
+                                className={`flex-1 px-4 py-3 text-[14px] leading-6 border-r border-[#E4E7EC] last:border-r-0 transition-colors ${
+                                    activeTab === tab
+                                        ? "text-[#0F2236] bg-[#EAEAEA] font-medium"
+                                        : "text-[#667085] bg-white hover:bg-[#F9FAFB] font-medium"
+                                }`}
+                            >
+                                {tab === "pet" && "Pet Details"}
+                                {tab === "transfer" && "Transfer Details"}
+                                {tab === "adopter" && "Adopter's Details"}
+                            </button>
+                        ))}
+                    </div>
                 </div>
 
-                <div className="flex-1 overflow-y-auto p-6 scrollbar-minimal">
+                <div className="flex-1 overflow-y-auto px-9 pt-8 pb-9 scrollbar-minimal">
                     {activeTab === "pet" && (
-                        <div className="flex flex-col items-center">
-                            <div className="w-24 h-24 rounded-full overflow-hidden border-2 border-gray-100 mb-6">
+                        <div>
+                            <div className="w-[128px] h-[128px] rounded-xl overflow-hidden border border-[#E4E7EC] mb-6">
                                 <img
                                     src={data.pet.imageUrl}
                                     alt={data.pet.name}
                                     className="w-full h-full object-cover"
                                 />
                             </div>
-                            <div className="w-full space-y-3 text-left">
-                                <Row label="Pet Type" value={data.pet.petType} />
-                                <Row label="Breed" value={data.pet.breed} />
-                                <Row label="Age" value={data.pet.age} />
-                                <Row label="Gender" value={data.pet.gender} />
-                                <Row label="Vaccinated Status" value={data.pet.vaccinated} />
+                            <div className="w-full">
+                                <InlineRow label="Pet Type" value={data.pet.petType} />
+                                <InlineRow label="Breed" value={data.pet.breed} />
+                                <InlineRow label="Age" value={data.pet.age} />
+                                <InlineRow label="Gender" value={data.pet.gender} />
+                                <InlineRow label="Vaccinated Status" value={data.pet.vaccinated} isLast />
                             </div>
                         </div>
                     )}
                     {activeTab === "transfer" && (
-                        <div className="space-y-3">
-                            <Row label="Date Transferred" value={data.transfer.dateTransferred} />
-                            <Row label="Transfer Location / Address" value={data.transfer.transferAddress} />
+                        <div className="pt-2">
+                            <InlineRow label="Date Transferred" value={data.transfer.dateTransferred} />
+                            <InlineRow label="Transfer Location / Address" value={data.transfer.transferAddress} isLast />
                         </div>
                     )}
                     {activeTab === "adopter" && (
-                        <div className="flex flex-col items-center">
-                            <div className="w-20 h-20 rounded-full overflow-hidden border-2 border-gray-100 mb-4">
+                        <div>
+                            <div className="w-[122px] h-[122px] rounded-xl overflow-hidden border border-[#E4E7EC] mb-6">
                                 <img
                                     src={data.adopter.imageUrl}
                                     alt={data.adopter.fullName}
                                     className="w-full h-full object-cover"
                                 />
                             </div>
-                            <div className="w-full space-y-3 text-left">
-                                <Row label="Full Name" value={data.adopter.fullName} />
+                            <div className="w-full">
+                                <InlineRow label="Full Name" value={data.adopter.fullName} />
                                 {data.adopter.profileId && onAdopterClick ? (
-                                    <div className="py-2">
-                                        <p className="text-[13px] text-gray-400 mb-1">Location</p>
+                                    <div className="grid grid-cols-[1fr_1.7fr] items-center py-3 border-b border-[#EAECF0]">
+                                        <p className="text-[15px] leading-6 text-[#667085]">Location:</p>
                                         <button
                                             type="button"
                                             onClick={() => onAdopterClick(data.adopter.profileId!)}
-                                            className="text-[15px] font-semibold text-[#0D162B] hover:text-[#E84D2A] underline underline-offset-2"
+                                            className="text-left text-[15px] leading-6 font-semibold text-[#0F2236] hover:text-[#0F2236]"
                                         >
                                             {data.adopter.location}
                                         </button>
                                     </div>
                                 ) : (
-                                    <Row label="Location" value={data.adopter.location} />
+                                    <InlineRow label="Location" value={data.adopter.location} isLast />
                                 )}
                             </div>
                         </div>
@@ -142,11 +144,19 @@ export function ListingDetailsModal({
     );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
+function InlineRow({
+    label,
+    value,
+    isLast = false,
+}: {
+    label: string;
+    value: string;
+    isLast?: boolean;
+}) {
     return (
-        <div className="py-2 border-b border-gray-100 last:border-0">
-            <p className="text-[13px] text-gray-400 mb-0.5">{label}</p>
-            <p className="text-[15px] font-semibold text-[#0D162B]">{value}</p>
+        <div className={`grid grid-cols-[1fr_1.7fr] items-center py-3 ${isLast ? "" : "border-b border-[#EAECF0]"}`}>
+            <p className="text-[15px] leading-6 text-[#667085]">{label}:</p>
+            <p className="text-[15px] leading-6 font-semibold text-[#0F2236]">{value}</p>
         </div>
     );
 }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -120,117 +120,116 @@ export default function ProfilePage() {
     const listingDetails = listingDetailsId ? getListingDetails(listingDetailsId) : null;
 
     const handleListerClick = (_profileId: string) => {
+        void _profileId;
         setAdoptionDetailsId(null);
         navigate(`/profile`);
     };
 
     const handleAdopterClick = (_profileId: string) => {
+        void _profileId;
         setListingDetailsId(null);
         navigate("/profile");
     };
 
     return (
-        <div className="min-h-screen flex flex-col pb-12">
-            <div className="bg-white border-b border-gray-100 h-20 mb-8 shrink-0" />
+        <div className="min-h-full bg-[#F7F7F8] py-6 sm:py-8 lg:py-10">
+            <div className="max-w-[1240px] w-full mx-auto px-4 sm:px-6 lg:px-8 flex flex-col lg:flex-row gap-6 lg:gap-7">
 
-            <div className="max-w-[1280px] w-full mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row gap-6 lg:gap-8 flex-1">
+                <div className="w-full lg:w-[336px] border border-[#EBEDF0] rounded-xl px-6 py-7 sm:px-7 sm:py-8 bg-white flex flex-col items-center">
 
-                <div className="w-full md:w-[340px] lg:w-[380px] border border-gray-200 rounded-2xl p-6 sm:p-8 md:p-10 bg-white flex flex-col items-center shadow-sm">
-
-                    <div className="relative mb-4">
-                        <div className="w-60 h-60 rounded-full overflow-hidden border-4 border-white shadow-sm">
+                    <div className="relative mb-5">
+                        <div className="w-36 h-36 rounded-full overflow-hidden border border-[#EBEDF0]">
                             <img src={ownerImg} alt="Profile" className="w-full h-full object-cover" />
                         </div>
-                        <button className="absolute bottom-5 right-5 w-8 h-8 bg-white rounded-full flex items-center justify-center shadow-md border border-gray-100 text-gray-500 hover:text-gray-900 transition-colors">
-                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                        <button className="absolute bottom-1 right-1 w-8 h-8 bg-white rounded-full flex items-center justify-center border border-[#D6DAE0] text-[#4A5568] hover:text-[#0D162B] transition-colors">
+                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 3H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M18.375 2.625a1.5 1.5 0 113 3L12 15l-4 1 1-4 9.375-9.375z" />
                             </svg>
                         </button>
                     </div>
 
-                    <div className="flex items-center gap-1.5 px-3 py-1 bg-[#E8F5E9] text-[#22C55E] rounded-md mb-8">
-                        <span className="text-[13px] font-semibold tracking-wide">Account Verified</span>
-                        <svg className="w-[14px] h-[14px]" fill="currentColor" viewBox="0 0 20 20">
+                    <div className="flex items-center gap-1.5 px-3 py-1 bg-[#EAF8EE] text-[#2BA84A] rounded-md mb-7">
+                        <span className="text-[16px] leading-5 font-semibold">Account Verified</span>
+                        <svg className="w-[18px] h-[18px]" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                         </svg>
                     </div>
 
                     <div className="w-full flex flex-col">
-                        <div className="py-4 border-b border-gray-100">
-                            <p className="text-[13px] text-gray-400 mb-1">Full Name</p>
-                            <p className="text-[15px] font-semibold text-[#0D162B]">Angela Christoper</p>
+                        <div className="py-4 border-b border-[#ECEFF3]">
+                            <p className="text-[16px] leading-5 text-[#98A1AF] mb-0.5">Full Name</p>
+                            <p className="text-[16px] leading-8 font-semibold text-[#0D162B]">Angela Christoper</p>
                         </div>
-                        <div className="py-4 border-b border-gray-100">
-                            <p className="text-[13px] text-gray-400 mb-1">Email Address</p>
-                            <p className="text-[15px] font-semibold text-[#0D162B]">Angela@gmail.com</p>
+                        <div className="py-4 border-b border-[#ECEFF3]">
+                            <p className="text-[16px] leading-5 text-[#98A1AF] mb-0.5">Email Address</p>
+                            <p className="text-[16px] leading-8 font-semibold text-[#0D162B]">Angela@gmail.com</p>
                         </div>
-                        <div className="py-4 border-b border-gray-100">
-                            <p className="text-[13px] text-gray-400 mb-1">Phone Number</p>
-                            <p className="text-[15px] font-semibold text-[#0D162B]">+234 903 123 1233</p>
+                        <div className="py-4 border-b border-[#ECEFF3]">
+                            <p className="text-[16px] leading-5 text-[#98A1AF] mb-0.5">Phone Number</p>
+                            <p className="text-[16px] leading-8 font-semibold text-[#0D162B]">+234 903 123 1233</p>
                         </div>
-                        <div className="py-4 pt-4">
-                            <p className="text-[13px] text-gray-400 mb-1">Location</p>
-                            <p className="text-[15px] font-semibold text-[#0D162B] leading-snug">
+                        <div className="py-4">
+                            <p className="text-[16px] leading-5 text-[#98A1AF] mb-0.5">Location</p>
+                            <p className="ttext-[16px] leading-8 font-semibold text-[#0D162B]">
                                 24 Just Street, Lekki, Lagos, Nigeria
                             </p>
                         </div>
                     </div>
                 </div>
 
-                <div className="flex-1 border border-gray-200 rounded-2xl bg-white overflow-hidden flex flex-col shadow-sm min-h-[600px] md:h-[calc(100vh-140px)]">
+                <div className="flex-1 border border-[#EBEDF0] rounded-xl bg-white overflow-hidden flex flex-col min-h-[560px]">
 
-                    <div className="flex bg-white">
+                    <div className="flex bg-white border-b border-[#ECEFF3]">
                         <button
                             onClick={() => setActiveTab("adoption")}
-                            className={`px-6 sm:px-8 py-5 text-[14px] sm:text-[15px] font-semibold outline-none transition-all border-r border-b border-gray-200
+                            className={`px-5 sm:px-8 py-4 text-[18px] sm:text-[15px] leading-6 font-bold outline-none transition-colors border-r border-[#ECEFF3]
                                 ${activeTab === "adoption"
-                                    ? "bg-gray-50 text-[#0D162B] border-b-transparent focus:ring-0"
-                                    : "bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700"}`}
+                                    ? "bg-[#EAEAEA] text-[#0D162B]"
+                                    : "bg-white text-[#7A8495] hover:bg-[#F8F9FA] hover:text-[#475467]"}`}
                         >
                             Adoption Record
                         </button>
                         <button
                             onClick={() => setActiveTab("listing")}
-                            className={`px-6 sm:px-8 py-5 text-[14px] sm:text-[15px] font-semibold outline-none transition-all border-r border-b border-gray-200
+                            className={`px-5 sm:px-8 py-4 text-[18px] sm:text-[15px] leading-6 font-bold outline-none transition-colors border-r border-[#ECEFF3]
                                 ${activeTab === "listing"
-                                    ? "bg-gray-50 text-[#0D162B] border-b-transparent focus:ring-0"
-                                    : "bg-white text-gray-500 hover:bg-gray-50 hover:text-gray-700"}`}
+                                    ? "bg-[#EAEAEA] text-[#0D162B]"
+                                    : "bg-white text-[#7A8495] hover:bg-[#F8F9FA] hover:text-[#475467]"}`}
                         >
                             Listing Record
                         </button>
-                        <div className="flex-1 border-b border-gray-200 bg-white" />
+                        <div className="flex-1 bg-white" />
                     </div>
 
                     {activeTab === "adoption" && adoptionRecords.length > 0 && (
-                        <div className="flex-1 overflow-auto">
-                            <div className="hidden md:grid grid-cols-[1fr_auto_auto] gap-4 px-6 py-4 border-b border-gray-100 bg-gray-50/50 text-[13px] font-semibold text-gray-500 uppercase tracking-wide">
-                                <div>Details</div>
-                                <div className="min-w-[120px]">Date Received</div>
-                                <div className="min-w-[100px]">Action</div>
+                        <div className="flex-1 overflow-auto p-4 sm:p-5">
+                            <div className="hidden md:grid grid-cols-[1fr_auto_auto] gap-4 px-4 py-3 text-[13px] leading-5 font-bold text-[#4D5761]">
+                                <div className="text-[14px]">Details</div>
+                                <div className="min-w-[120px] text-[14px]">Date Received</div>
+                                <div className="min-w-[100px] text-[14px]">Action</div>
                             </div>
-                            <ul className="divide-y divide-gray-100">
+                            <ul className="space-y-3">
                                 {adoptionRecords.map((record) => (
-                                    <li key={record.id} className="px-4 sm:px-6 py-4 hover:bg-gray-50/50 transition-colors">
-                                        <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                                    <li key={record.id} className="px-3.5 sm:px-4 py-3 border border-[#ECEFF3] rounded-xl hover:bg-[#FAFAFA] transition-colors">
+                                        <div className="flex flex-col gap-4 md:grid md:grid-cols-[1fr_120px_100px] md:items-center md:gap-4">
                                             <div className="flex flex-1 items-center gap-4 min-w-0">
-                                                <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg overflow-hidden shrink-0 bg-gray-100">
+                                                <div className="w-14 h-14 rounded-md overflow-hidden shrink-0 bg-[#F3F4F6]">
                                                     <img src={record.petImage} alt={record.petName} className="w-full h-full object-cover" />
                                                 </div>
                                                 <div className="min-w-0">
-                                                    <h3 className="text-[15px] font-bold text-[#0D162B]">{record.petName}</h3>
-                                                    <p className="text-[13px] text-gray-500 mt-0.5">{record.petDescription}</p>
+                                                    <h3 className="text-[16px] leading-8 font-bold text-[#0D162B]">{record.petName}</h3>
+                                                    <p className="text-[12px] leading-6 text-[#7A8495] mt-0.5">{record.petDescription}</p>
                                                 </div>
                                             </div>
-                                            <div className="flex items-center justify-between sm:justify-end gap-4 sm:gap-6">
-                                                <span className="text-[14px] text-gray-600 sm:min-w-[120px]">{record.dateReceived}</span>
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setAdoptionDetailsId(record.id)}
-                                                    className="text-[14px] font-semibold text-[#E84D2A] hover:text-[#d4431f] underline underline-offset-2 shrink-0"
-                                                >
-                                                    View Adoption Details
-                                                </button>
-                                            </div>
+                                            <span className="text-[14px] leading-6 text-[#475467] md:justify-self-start">{record.dateReceived}</span>
+                                            <button
+                                                type="button"
+                                                onClick={() => setAdoptionDetailsId(record.id)}
+                                                className="text-left text-[14px] leading-6 font-medium text-[#1D2939] hover:text-[#0F1728] underline underline-offset-2 shrink-0 md:justify-self-start"
+                                            >
+                                                View Details
+                                            </button>
                                         </div>
                                     </li>
                                 ))}
@@ -262,35 +261,33 @@ export default function ProfilePage() {
                     )}
 
                     {activeTab === "listing" && listingRecords.length > 0 && (
-                        <div className="flex-1 overflow-auto">
-                            <div className="hidden md:grid grid-cols-[1fr_auto_auto] gap-4 px-6 py-4 border-b border-gray-100 bg-gray-50/50 text-[13px] font-semibold text-gray-500 uppercase tracking-wide">
-                                <div>Details</div>
-                                <div className="min-w-[120px]">Date Transferred</div>
-                                <div className="min-w-[100px]">Action</div>
+                        <div className="flex-1 overflow-auto p-4 sm:p-5">
+                            <div className="hidden md:grid grid-cols-[1fr_auto_auto] gap-4 px-4 py-3 text-[13px] leading-5 font-bold text-[#4D5761]">
+                                <div className="text-[14px]">Details</div>
+                                <div className="min-w-[120px] text-[14px]">Date Transferred</div>
+                                <div className="min-w-[100px] text-[14px]">Action</div>
                             </div>
-                            <ul className="divide-y divide-gray-100">
+                            <ul className="space-y-3">
                                 {listingRecords.map((record) => (
-                                    <li key={record.id} className="px-4 sm:px-6 py-4 hover:bg-gray-50/50 transition-colors">
-                                        <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                                    <li key={record.id} className="px-3.5 sm:px-4 py-3 border border-[#ECEFF3] rounded-xl hover:bg-[#FAFAFA] transition-colors">
+                                        <div className="flex flex-col gap-4 md:grid md:grid-cols-[1fr_120px_100px] md:items-center md:gap-4">
                                             <div className="flex flex-1 items-center gap-4 min-w-0">
-                                                <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-lg overflow-hidden shrink-0 bg-gray-100">
+                                                <div className="w-14 h-14 rounded-md overflow-hidden shrink-0 bg-[#F3F4F6]">
                                                     <img src={record.petImage} alt={record.petName} className="w-full h-full object-cover" />
                                                 </div>
                                                 <div className="min-w-0">
-                                                    <h3 className="text-[15px] font-bold text-[#0D162B]">{record.petName}</h3>
-                                                    <p className="text-[13px] text-gray-500 mt-0.5">{record.petDescription}</p>
+                                                    <h3 className="text-[16px] leading-8 font-semibold text-[#0D162B]">{record.petName}</h3>
+                                                    <p className="text-[12px] leading-6 text-[#7A8495] mt-0.5">{record.petDescription}</p>
                                                 </div>
                                             </div>
-                                            <div className="flex items-center justify-between sm:justify-end gap-4 sm:gap-6">
-                                                <span className="text-[14px] text-gray-600 sm:min-w-[120px]">{record.dateTransferred}</span>
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setListingDetailsId(record.id)}
-                                                    className="text-[14px] font-semibold text-[#E84D2A] hover:text-[#d4431f] underline underline-offset-2 shrink-0"
-                                                >
-                                                    View Details
-                                                </button>
-                                            </div>
+                                            <span className="text-[14px] leading-6 text-[#475467] md:justify-self-start">{record.dateTransferred}</span>
+                                            <button
+                                                type="button"
+                                                onClick={() => setListingDetailsId(record.id)}
+                                                className="text-left text-[14px] leading-6 font-medium text-[#1D2939] hover:text-[#0F1728] underline underline-offset-2 shrink-0 md:justify-self-start"
+                                            >
+                                                View Details
+                                            </button>
                                         </div>
                                     </li>
                                 ))}


### PR DESCRIPTION
## Issue

Closes #93 

## Overview
This PR focuses on refining the UI/UX of the `/profile` page to align the current implementation with the approved Figma design. The scope is limited to visual and responsiveness updates, while preserving existing functionality and component behavior.

## Summary
- Refined the `/profile` UI to align with the approved design system, including layout spacing, typography hierarchy, color usage, and responsive behavior across mobile/tablet/desktop.
- Updated records presentation (`Adoption Record` and `Listing Record`) for better visual consistency and proper column alignment so `Date` and `Action` headers match their corresponding content.
- Redesigned `AdoptionDetailsModal` and `ListingDetailsModal` to match the latest mockups across all tabs (`Pet`, `Receipt/Transfer`, `Lister/Adopter`), including tab styling, row structure, image blocks, spacing, and header/close visuals.
- Applied a targeted update to the profile edit icon to match the requested reference style while preserving behavior.
- No business logic changes were introduced, and modified files are lint-clean.

## Screenshots

<div align="center">
<img width="1409" height="781" alt="image" src="https://github.com/user-attachments/assets/614bb7cf-fd7e-459a-944f-05b90715c80e" />

<img width="1393" height="752" alt="image" src="https://github.com/user-attachments/assets/676b1aa7-cc67-429e-a3b9-63208ef70518" />

<img width="672" height="756" alt="image" src="https://github.com/user-attachments/assets/14b41a73-22b5-447b-96c4-aa60bacc69ee" />

<img width="626" height="544" alt="image" src="https://github.com/user-attachments/assets/505e88d5-feb8-4142-bfaf-00c2fa9a2172" />

<img width="665" height="610" alt="image" src="https://github.com/user-attachments/assets/731b895a-5c8e-44f4-84f9-d0508e9ae492" />

<img width="688" height="497" alt="image" src="https://github.com/user-attachments/assets/b403f246-e2cc-47f4-9d0c-cf9e32ce9d20" />

<img width="635" height="906" alt="image" src="https://github.com/user-attachments/assets/c56aa55a-471e-49a8-b669-fb7bc3a7bc58" />

<img width="437" height="847" alt="image" src="https://github.com/user-attachments/assets/9d0a6aa8-dcf3-472c-a928-809fb4f4818f" />

<img width="573" height="886" alt="image" src="https://github.com/user-attachments/assets/b42736af-bc50-494c-bb62-8c4a3eeb4467" />

<img width="551" height="818" alt="image" src="https://github.com/user-attachments/assets/14ff4cba-6551-493f-80a2-36734bf18264" />

<img width="583" height="816" alt="image" src="https://github.com/user-attachments/assets/51c42ce6-1b46-4353-a269-ec5613bcb0cb" />

<img width="713" height="859" alt="image" src="https://github.com/user-attachments/assets/da9329ab-6523-41c3-bee1-0c634993c4af" />

<img width="624" height="858" alt="image" src="https://github.com/user-attachments/assets/1d984038-958b-48c2-ba79-0080814958aa" />

<img width="640" height="856" alt="image" src="https://github.com/user-attachments/assets/075d25c2-74d0-49d9-a646-a7dab2f08caa" />

<img width="676" height="862" alt="image" src="https://github.com/user-attachments/assets/38a93eee-3c5a-452e-8698-896ee7d079ec" />

<img width="685" height="847" alt="image" src="https://github.com/user-attachments/assets/b8f4f52f-bc60-4b92-88e7-0db5b3d7fa08" />


</div>



---
@amina69 Please review this PR when you have a moment. Thank you!