### PR TITLE
add api error classes and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1963,7 +1962,6 @@
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1974,7 +1972,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2034,7 +2031,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2425,7 +2421,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2576,7 +2571,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2916,7 +2910,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3198,9 +3191,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4020,7 +4013,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4111,7 +4103,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4121,7 +4112,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4510,7 +4500,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4606,7 +4595,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4892,7 +4880,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/__tests__/api-errors.test.ts
+++ b/src/lib/__tests__/api-errors.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+	ApiError,
+	ValidationApiError,
+	NotFoundError,
+	ForbiddenError,
+} from "../api-errors";
+
+describe("Api errors", () => {
+	it("supports instanceof checks for ApiError", () => {
+		const error = new ApiError("Base error", { status: 500, code: "ERR" });
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error).toBeInstanceOf(Error);
+		expect(error.status).toBe(500);
+		expect(error.code).toBe("ERR");
+	});
+
+	it("supports instanceof checks for ValidationApiError", () => {
+		const fields = { email: ["Required"] };
+		const error = new ValidationApiError("Invalid input", fields, {
+			status: 422,
+			code: "VALIDATION_ERROR",
+		});
+
+		expect(error).toBeInstanceOf(ValidationApiError);
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error.fields).toEqual(fields);
+	});
+
+	it("supports instanceof checks for NotFoundError", () => {
+		const error = new NotFoundError("Missing", {
+			status: 404,
+			code: "NOT_FOUND",
+		});
+		expect(error).toBeInstanceOf(NotFoundError);
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error.status).toBe(404);
+	});
+
+	it("supports instanceof checks for ForbiddenError", () => {
+		const error = new ForbiddenError("Denied", {
+			status: 403,
+			code: "FORBIDDEN",
+		});
+		expect(error).toBeInstanceOf(ForbiddenError);
+		expect(error).toBeInstanceOf(ApiError);
+		expect(error.status).toBe(403);
+	});
+});

--- a/src/lib/__tests__/apiClient.test.ts
+++ b/src/lib/__tests__/apiClient.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 import type { ApiClientConfig } from "../../types/auth";
+import {
+	ApiError,
+	NotFoundError,
+	ValidationApiError,
+	ForbiddenError,
+} from "../api-errors";
 import { createApiClient, getApiClient } from "../api-client";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -228,14 +234,16 @@ describe("ApiClient", () => {
 	// ── Error handling ────────────────────────────────────────────────────────
 
 	describe("error handling", () => {
-		it("throws an ApiError with status on non-2xx responses", async () => {
+		it("throws a NotFoundError on 404 responses", async () => {
 			fetchMock.mockResolvedValueOnce(
 				makeResponse({ message: "Not found" }, 404),
 			);
 			const client = freshClient();
 
-			await expect(client.get("/missing")).rejects.toMatchObject({
-				name: "ApiError",
+			const promise = client.get("/missing");
+
+			await expect(promise).rejects.toBeInstanceOf(NotFoundError);
+			await expect(promise).rejects.toMatchObject({
 				status: 404,
 				message: "Not found",
 			});
@@ -269,9 +277,7 @@ describe("ApiClient", () => {
 		});
 
 		it("re-throws existing ApiErrors without wrapping them", async () => {
-			const original: any = new Error("Already an api error");
-			original.name = "ApiError";
-			original.status = 422;
+			const original = new ApiError("Already an api error", { status: 422 });
 			fetchMock.mockRejectedValueOnce(original);
 			const client = freshClient();
 
@@ -285,6 +291,39 @@ describe("ApiClient", () => {
 			await expect(client.get("/test")).rejects.toMatchObject({
 				name: "ApiError",
 				message: "Some unexpected error",
+			});
+		});
+
+		it("throws a ValidationApiError on 422 responses", async () => {
+			fetchMock.mockResolvedValueOnce(
+				makeResponse(
+					{ message: "Invalid input", fields: { email: ["Required"] } },
+					422,
+				),
+			);
+			const client = freshClient();
+
+			const promise = client.get("/invalid");
+
+			await expect(promise).rejects.toBeInstanceOf(ValidationApiError);
+			await expect(promise).rejects.toMatchObject({
+				status: 422,
+				fields: { email: ["Required"] },
+			});
+		});
+
+		it("throws a ForbiddenError on 403 responses", async () => {
+			fetchMock.mockResolvedValueOnce(
+				makeResponse({ message: "Forbidden" }, 403),
+			);
+			const client = freshClient();
+
+			const promise = client.get("/forbidden");
+
+			await expect(promise).rejects.toBeInstanceOf(ForbiddenError);
+			await expect(promise).rejects.toMatchObject({
+				status: 403,
+				message: "Forbidden",
 			});
 		});
 	});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,4 +1,10 @@
-import type { ApiClientConfig, ApiError } from "../types/auth";
+import type { ApiClientConfig } from "../types/auth";
+import {
+	ApiError,
+	ForbiddenError,
+	NotFoundError,
+	ValidationApiError,
+} from "./api-errors";
 
 class ApiClient {
 	private baseURL: string;
@@ -50,11 +56,10 @@ class ApiClient {
 
 				this.onUnauthorized?.();
 
-				const error: ApiError = new Error("Unauthorized access");
-				error.status = 401;
-				error.name = "ApiError";
-
-				throw error;
+				throw new ApiError("Unauthorized access", {
+					status: 401,
+					code: "UNAUTHORIZED",
+				});
 			}
 
 			let errorData: unknown;
@@ -76,11 +81,44 @@ class ApiClient {
 				errorData = `Request failed with status ${response.status}`;
 			}
 
-			const error: ApiError = new Error(message);
-			error.status = response.status;
-			error.data = errorData;
-			error.name = "ApiError";
-			throw error;
+			const code = (errorData as { code?: string } | undefined)?.code;
+
+			if (response.status === 403) {
+				throw new ForbiddenError(message, {
+					status: 403,
+					code,
+					data: errorData,
+				});
+			}
+
+			if (response.status === 404) {
+				throw new NotFoundError(message, {
+					status: 404,
+					code,
+					data: errorData,
+				});
+			}
+
+			if (response.status === 422) {
+				const fields =
+					(errorData as { fields?: Record<string, string[]> } | undefined)
+						?.fields ??
+					(errorData as { errors?: Record<string, string[]> } | undefined)
+						?.errors ??
+					{};
+
+				throw new ValidationApiError(message, fields, {
+					status: 422,
+					code,
+					data: errorData,
+				});
+			}
+
+			throw new ApiError(message, {
+				status: response.status,
+				code,
+				data: errorData,
+			});
 		}
 
 		// Handle empty responses
@@ -111,25 +149,21 @@ class ApiClient {
 		} catch (error) {
 			// Check if it's a network error
 			if (error instanceof TypeError && error.message === "Failed to fetch") {
-				const networkError: ApiError = new Error(
-					"Network error - please check your connection",
-				);
-				networkError.isNetworkError = true;
-				networkError.name = "ApiError";
-				throw networkError;
+				throw new ApiError("Network error - please check your connection", {
+					code: "NETWORK_ERROR",
+					isNetworkError: true,
+				});
 			}
 
 			// Re-throw if it's already an ApiError
-			if ((error as ApiError).name === "ApiError") {
+			if (error instanceof ApiError || (error as Error).name === "ApiError") {
 				throw error;
 			}
 
 			// Wrap unknown errors
-			const wrappedError: ApiError = new Error(
+			throw new ApiError(
 				error instanceof Error ? error.message : "Unknown error occurred",
 			);
-			wrappedError.name = "ApiError";
-			throw wrappedError;
 		}
 	}
 

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,73 @@
+export class ApiError extends Error {
+	status?: number;
+	code?: string;
+	data?: unknown;
+	isNetworkError?: boolean;
+
+	constructor(
+		message: string,
+		options?: {
+			status?: number;
+			code?: string;
+			data?: unknown;
+			isNetworkError?: boolean;
+		},
+	) {
+		super(message);
+		this.name = "ApiError";
+		this.status = options?.status;
+		this.code = options?.code;
+		this.data = options?.data;
+		this.isNetworkError = options?.isNetworkError;
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+export class ValidationApiError extends ApiError {
+	fields: Record<string, string[]>;
+
+	constructor(
+		message: string,
+		fields: Record<string, string[]>,
+		options?: {
+			status?: number;
+			code?: string;
+			data?: unknown;
+		},
+	) {
+		super(message, options);
+		this.name = "ValidationApiError";
+		this.fields = fields;
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+export class NotFoundError extends ApiError {
+	constructor(
+		message: string,
+		options?: {
+			status?: number;
+			code?: string;
+			data?: unknown;
+		},
+	) {
+		super(message, options);
+		this.name = "NotFoundError";
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}
+
+export class ForbiddenError extends ApiError {
+	constructor(
+		message: string,
+		options?: {
+			status?: number;
+			code?: string;
+			data?: unknown;
+		},
+	) {
+		super(message, options);
+		this.name = "ForbiddenError";
+		Object.setPrototypeOf(this, new.target.prototype);
+	}
+}


### PR DESCRIPTION
closed: #97 
## Summary
- Add shared API error classes (`ApiError`, `ValidationApiError`, `NotFoundError`, `ForbiddenError`)
- Update API client to throw specific error types based on status codes
- Add/adjust tests to validate `instanceof` behavior and new error handling

## Changes
- `ApiError` base class with `status`, `code`, and optional metadata
- `ValidationApiError` includes `fields: Record<string, string[]>`
- `api-client` now throws:
  - `ForbiddenError` for 403
  - `NotFoundError` for 404
  - `ValidationApiError` for 422
- Tests updated/added to cover new error types

## Testing
- `npx vitest`

## Notes
- Preserves existing behavior for other non-2xx responses (still `ApiError`)

#97 