### PR TITLE
feat(utils): add Stellar explorer URL helper and tx hash truncation utility with tests

### DIFF
--- a/src/lib/__tests__/stellar.test.ts
+++ b/src/lib/__tests__/stellar.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stellarExplorerUrl, truncateTxHash } from "../stellar";
+
+describe("stellar utilities", () => {
+  beforeEach(() => {
+    // Clear environment variables before each test
+    vi.stubEnv("VITE_STELLAR_NETWORK", undefined);
+  });
+
+  describe("stellarExplorerUrl", () => {
+    it("returns testnet URL when VITE_STELLAR_NETWORK is testnet", () => {
+      vi.stubEnv("VITE_STELLAR_NETWORK", "testnet");
+      const txHash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      
+      const result = stellarExplorerUrl(txHash);
+      
+      expect(result).toBe("https://stellar.expert/explorer/testnet/tx/" + txHash);
+    });
+
+    it("returns mainnet URL when VITE_STELLAR_NETWORK is mainnet", () => {
+      vi.stubEnv("VITE_STELLAR_NETWORK", "mainnet");
+      const txHash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      
+      const result = stellarExplorerUrl(txHash);
+      
+      expect(result).toBe("https://stellar.expert/explorer/public/tx/" + txHash);
+    });
+
+    it("defaults to testnet URL when VITE_STELLAR_NETWORK is not set", () => {
+      const txHash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      
+      const result = stellarExplorerUrl(txHash);
+      
+      expect(result).toBe("https://stellar.expert/explorer/testnet/tx/" + txHash);
+    });
+
+    it("throws error when txHash is empty", () => {
+      expect(() => stellarExplorerUrl("")).toThrow("Transaction hash is required");
+    });
+
+    it("throws error when txHash is null", () => {
+      expect(() => stellarExplorerUrl(null as unknown as string)).toThrow("Transaction hash is required");
+    });
+
+    it("throws error when txHash is undefined", () => {
+      expect(() => stellarExplorerUrl(undefined as unknown as string)).toThrow("Transaction hash is required");
+    });
+  });
+
+  describe("truncateTxHash", () => {
+    it("truncates long transaction hash correctly", () => {
+      const txHash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+      
+      const result = truncateTxHash(txHash);
+      
+      expect(result).toBe("abcdef12...34567890");
+    });
+
+    it("returns original hash when length is 16 characters or less", () => {
+      const shortHash = "123456789012345";
+      
+      const result = truncateTxHash(shortHash);
+      
+      expect(result).toBe("123456789012345");
+    });
+
+    it("returns original hash when length is exactly 16 characters", () => {
+      const exactHash = "1234567890123456";
+      
+      const result = truncateTxHash(exactHash);
+      
+      expect(result).toBe("1234567890123456");
+    });
+
+    it("returns empty string when txHash is empty", () => {
+      const result = truncateTxHash("");
+      
+      expect(result).toBe("");
+    });
+
+    it("returns empty string when txHash is null", () => {
+      const result = truncateTxHash(null as unknown as string);
+      
+      expect(result).toBe("");
+    });
+
+    it("returns empty string when txHash is undefined", () => {
+      const result = truncateTxHash(undefined as unknown as string);
+      
+      expect(result).toBe("");
+    });
+
+    it("handles hash with exactly 17 characters", () => {
+      const hash = "12345678901234567";
+      
+      const result = truncateTxHash(hash);
+      
+      expect(result).toBe("12345678...01234567");
+    });
+  });
+});

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -1,0 +1,41 @@
+/**
+ * Stellar utility functions for explorer URLs and transaction hash formatting
+ */
+
+/**
+ * Generates the correct Stellar explorer URL based on network environment
+ * @param txHash - The transaction hash to create URL for
+ * @returns The complete Stellar explorer URL
+ */
+export function stellarExplorerUrl(txHash: string): string {
+  if (!txHash) {
+    throw new Error("Transaction hash is required");
+  }
+
+  const network = import.meta.env.VITE_STELLAR_NETWORK || "testnet";
+  const baseUrl = network === "mainnet" 
+    ? "https://stellar.expert/explorer/public/tx/"
+    : "https://stellar.expert/explorer/testnet/tx/";
+  
+  return `${baseUrl}${txHash}`;
+}
+
+/**
+ * Truncates a transaction hash for display purposes
+ * Shows first 8 characters + "..." + last 8 characters
+ * @param txHash - The transaction hash to truncate
+ * @returns The truncated transaction hash
+ */
+export function truncateTxHash(txHash: string): string {
+  if (!txHash) {
+    return "";
+  }
+
+  if (txHash.length <= 16) {
+    return txHash;
+  }
+
+  const firstEight = txHash.slice(0, 8);
+  const lastEight = txHash.slice(-8);
+  return `${firstEight}...${lastEight}`;
+}


### PR DESCRIPTION
## Summary
Adds utility functions for generating Stellar explorer transaction URLs based on the active network and formatting transaction hashes for UI display.

## Changes
- Implemented `stellarExplorerUrl(txHash: string)`:
  - Dynamically resolves the correct explorer base URL using `VITE_STELLAR_NETWORK`
  - Supports both testnet and mainnet environments
  - Defaults to testnet when env is not set

- Implemented `truncateTxHash(txHash: string)`:
  - Truncates transaction hashes to `first 8 + … + last 8` format
  - Returns original value for short hashes

- Added unit tests:
  - Verifies correct URL generation for testnet and mainnet
  - Validates truncation logic and edge cases

## Example
- Testnet:
  `https://stellar.expert/explorer/testnet/tx/{txHash}`

- Mainnet:
  `https://stellar.expert/explorer/public/tx/{txHash}`

- Truncated display:
  `12345678…90abcdef`

## Notes
- Uses `import.meta.env.VITE_STELLAR_NETWORK` for environment-based switching
- Designed as a lightweight utility for reuse across components

## Checklist
- [x] Feature implemented
- [x] Unit tests added and passing
- [x] Follows project structure and conventions

Closes #103 