### PR TITLE
feat: Create useApiQuery base hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.0",
+        "@tanstack/react-query": "^5.95.2",
         "lucide-react": "^0.575.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -125,7 +126,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1824,6 +1824,32 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.95.2.tgz",
+      "integrity": "sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.95.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1963,7 +1989,6 @@
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1974,7 +1999,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2034,7 +2058,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2425,7 +2448,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2576,7 +2598,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2916,7 +2937,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4020,7 +4040,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4111,7 +4130,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4121,7 +4139,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4510,7 +4527,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4606,7 +4622,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4892,7 +4907,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.0",
+    "@tanstack/react-query": "^5.95.2",
     "lucide-react": "^0.575.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/hooks/__tests__/useApiQuery.test.tsx
+++ b/src/hooks/__tests__/useApiQuery.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useApiQuery } from '../useApiQuery';
+import { ApiError } from '../../types/auth';
+import React from 'react';
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+    return ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+};
+
+describe('useApiQuery', () => {
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset window.location mock
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, href: '' },
+        });
+    });
+
+    it('should return data successfully', async () => {
+        const mockData = { id: 1, name: 'Test Pet' };
+        const fetchFn = vi.fn().mockResolvedValue(mockData);
+
+        const { result } = renderHook(() => useApiQuery(['test'], fetchFn), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.data).toEqual(mockData);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('should handle 401 and redirect to login', async () => {
+        const error: ApiError = new Error('Unauthorized');
+        error.status = 401;
+        const fetchFn = vi.fn().mockRejectedValue(error);
+
+        const { result } = renderHook(() => useApiQuery(['auth-error'], fetchFn), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(window.location.href).toBe('/login');
+    });
+
+    it('should return isForbidden true for 403', async () => {
+        const error: ApiError = new Error('Forbidden');
+        error.status = 403;
+        const fetchFn = vi.fn().mockRejectedValue(error);
+
+        const { result } = renderHook(() => useApiQuery(['forbidden-error'], fetchFn), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isForbidden).toBe(true);
+        expect(result.current.isError).toBe(true);
+    });
+
+    it('should return isNotFound true for 404', async () => {
+        const error: ApiError = new Error('Not Found');
+        error.status = 404;
+        const fetchFn = vi.fn().mockRejectedValue(error);
+
+        const { result } = renderHook(() => useApiQuery(['notfound-error'], fetchFn), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.isNotFound).toBe(true);
+        expect(result.current.isError).toBe(true);
+    });
+});

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,48 @@
+import { useQuery, UseQueryOptions } from "@tanstack/react-query";
+import { ApiError } from "../types/auth";
+
+interface UseApiQueryReturn<T> {
+  data: T | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  isForbidden: boolean;
+  isNotFound: boolean;
+  error: ApiError | null;
+}
+
+/**
+ * A thin wrapper around useQuery that handles loading, error, and empty states consistently.
+ * 
+ * - 401 Unauthorized: Redirects to /login
+ * - 403 Forbidden: Returns isForbidden: true
+ * - 404 Not Found: Returns isNotFound: true
+ */
+export function useApiQuery<T>(
+  key: any[],
+  fetchFn: () => Promise<T>,
+  options?: Omit<UseQueryOptions<T, ApiError>, 'queryKey' | 'queryFn'>
+): UseApiQueryReturn<T> {
+  const { data, isLoading, isError, error } = useQuery<T, ApiError>({
+    queryKey: key,
+    queryFn: fetchFn,
+    ...options,
+  });
+
+  const status = error?.status;
+
+  // Handle 401 Unauthorized
+  if (status === 401) {
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+  }
+
+  return {
+    data,
+    isLoading,
+    isError,
+    isForbidden: status === 403,
+    isNotFound: status === 404,
+    error: error || null,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,25 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom' // 1. Import the Router
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter> {/* 2. Wrap your App */}
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter> {/* 2. Wrap your App */}
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,7 @@
-import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
 // cleanup DOM after each test
+// @ts-ignore
 afterEach(() => {
   cleanup();
 });


### PR DESCRIPTION
Implement a standardized API query hook that wraps TanStack Query's useQuery to handle common API error states consistently across the application.

Proposed Changes
[Refactor] Dependencies & Setup
[MODIFY] 
package.json
Add @tanstack/react-query and @tanstack/react-query-devtools (optional but recommended) to dependencies.
[MODIFY] 
main.tsx
Initialize QueryClient.
Wrap the application in QueryClientProvider.
[Core Hook Implementation]
[NEW] 
useApiQuery.ts
Create useApiQuery hook that uses useQuery.
Implement error mapping logic:
401: Redirect to /login.
403: Set isForbidden: true.
404: Set isNotFound: true.
Return a standardized object: { data, isLoading, isError, isForbidden, isNotFound, error }.

- Closes #100 