### PR TITLE
feat: add useUrlSyn hoot with URL syn and test also ran tests for each file created…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,7 +488,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -537,7 +536,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1906,7 +1904,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2010,7 +2009,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2490,6 +2488,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2523,6 +2522,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2805,6 +2805,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2823,7 +2824,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3840,6 +3842,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4088,6 +4091,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4103,6 +4107,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4146,7 +4151,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/src/hooks/useUrlSync.test.ts
+++ b/src/hooks/useUrlSync.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useUrlSync } from "./useUrlSync";
+
+describe("useUrlSync", () => {
+  it("reads initial state from URL", () => {
+    window.history.pushState({}, "", "/?status=OPEN&status=PENDING");
+
+    const { result } = renderHook(() =>
+      useUrlSync<{ status: string[] }>({ status: [] }),
+    );
+
+    expect(result.current[0].status).toEqual(["OPEN", "PENDING"]);
+  });
+
+  it("updates URL when state changes", () => {
+    const { result } = renderHook(() =>
+      useUrlSync<{ status: string[] }>({ status: [] }),
+    );
+
+    act(() => {
+      result.current[1]({ status: ["OPEN"] });
+    });
+
+    expect(window.location.search).toContain("status=OPEN");
+  });
+
+  it("restores state on browser back", () => {
+    // Step 1: start with empty URL
+    window.history.pushState({}, "", "/");
+
+    const { result } = renderHook(() =>
+      useUrlSync<{ status: string[] }>({ status: [] }),
+    );
+
+    // Step 2: update state (sets ?status=OPEN)
+    act(() => {
+      result.current[1]({ status: ["OPEN"] });
+    });
+
+    // Step 3: simulate going back to empty URL
+    window.history.replaceState({}, "", "/");
+
+    // Step 4: trigger popstate
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(result.current[0].status).toEqual([]);
+  });
+});

--- a/src/hooks/useUrlSync.ts
+++ b/src/hooks/useUrlSync.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback } from "react";
+
+function readFromUrl<T>(defaults: T): T {
+  const params = new URLSearchParams(window.location.search);
+  const result: any = { ...defaults };
+
+  Object.keys(defaults as any).forEach((key) => {
+    const values = params.getAll(key);
+
+    if (values.length > 1) {
+      result[key] = values;
+    } else if (values.length === 1) {
+      result[key] = values[0];
+    } else {
+      result[key] = (defaults as any)[key];
+    }
+  });
+
+  return result;
+}
+
+function writeToUrl(state: any) {
+  const params = new URLSearchParams();
+
+  Object.entries(state).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach((v) => params.append(key, v));
+    } else if (value !== undefined && value !== null) {
+      params.set(key, value as string);
+    }
+  });
+
+  const query = params.toString();
+  const newUrl = window.location.pathname + (query ? `?${query}` : "");
+
+  window.history.replaceState(null, "", newUrl);
+}
+
+export function useUrlSync<T extends Record<string, any>>(defaults: T) {
+  const [state, setState] = useState<T>(() => readFromUrl(defaults));
+
+  const setUrlState = useCallback((next: T) => {
+    setState(next);
+    writeToUrl(next);
+  }, []);
+
+  useEffect(() => {
+    const onPopState = () => {
+      setState(readFromUrl(defaults));
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => {
+      window.removeEventListener("popstate", onPopState);
+    };
+  }, [defaults]);
+
+  return [state, setUrlState] as const;
+}


### PR DESCRIPTION
Closes #106 
Implemented useUrlSync hook to sync filter and pagination state with URL query params.

## Features
- Reads initial state from URL with fallback to defaults
- Updates URL using replaceState (no history push)
- Supports array query params (?status=OPEN&status=PENDING)
- Syncs state on browser back/forward navigation

## Tests
- Initial state from URL
- State updates URL
- Browser back restores state

All tests are passing.