### PR TITLE
feat(hooks): add useApiMutation with optimistic update, rollback and …

### DIFF
--- a/src/hooks/__tests__/useApiMutation.test.tsx
+++ b/src/hooks/__tests__/useApiMutation.test.tsx
@@ -1,0 +1,262 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { useApiMutation } from "../useApiMutation";
+import { ApiError } from "../../lib/api-errors";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fresh QueryClient + wrapper for each test */
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { queryClient, wrapper };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useApiMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Basic happy-path ───────────────────────────────────────────────────────
+
+  it("calls mutationFn and returns data on success", async () => {
+    const mockData = { id: "1", name: "Buddy" };
+    const mutationFn = vi.fn().mockResolvedValue(mockData);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useApiMutation<typeof mockData, { name: string }>(mutationFn),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ name: "Buddy" });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    // TanStack Query v5 passes a second context object to mutationFn, so we
+    // only assert on the first (variables) argument.
+    expect(mutationFn).toHaveBeenCalledWith(
+      { name: "Buddy" },
+      expect.objectContaining({ client: expect.anything() }),
+    );
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  // ── Rollback on error ──────────────────────────────────────────────────────
+
+  it("calls onRollback with the snapshot when the mutation fails", async () => {
+    const snapshot = { pets: [{ id: "old" }] };
+    const onOptimisticUpdate = vi.fn().mockReturnValue(snapshot);
+    const onRollback = vi.fn();
+    const apiError = new ApiError("Server error", { status: 500 });
+    const mutationFn = vi.fn().mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useApiMutation<void, { name: string }>(mutationFn, {
+          onOptimisticUpdate,
+          onRollback,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ name: "Shadow" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(onOptimisticUpdate).toHaveBeenCalledWith({ name: "Shadow" });
+    expect(onRollback).toHaveBeenCalledTimes(1);
+    // First arg must be the snapshot, second must be the ApiError
+    expect(onRollback).toHaveBeenCalledWith(snapshot, apiError);
+    expect(result.current.error).toBe(apiError);
+  });
+
+  it("does not throw when onRollback is not provided", async () => {
+    const mutationFn = vi
+      .fn()
+      .mockRejectedValue(new ApiError("Oops", { status: 500 }));
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useApiMutation<void, void>(mutationFn),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate(undefined as void);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    // No crash – test simply completing is enough
+  });
+
+  // ── Query invalidation on success ─────────────────────────────────────────
+
+  it("invalidates the specified query keys after a successful mutation", async () => {
+    const mutationFn = vi.fn().mockResolvedValue({ ok: true });
+    const { queryClient, wrapper } = createWrapper();
+
+    // Pre-seed a couple of queries so we can spy on invalidation
+    queryClient.setQueryData(["pets"], [{ id: "1" }]);
+    queryClient.setQueryData(["adoptions"], [{ id: "a1" }]);
+
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(
+      () =>
+        useApiMutation<{ ok: boolean }, void>(mutationFn, {
+          invalidates: [["pets"], ["adoptions"]],
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate(undefined as void);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    // invalidateQueries should have been called once for each key
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["pets"],
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ["adoptions"],
+    });
+  });
+
+  it("does not invalidate any queries when invalidates is not provided", async () => {
+    const mutationFn = vi.fn().mockResolvedValue({ ok: true });
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(
+      () => useApiMutation<{ ok: boolean }, void>(mutationFn),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate(undefined as void);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Optimistic update ──────────────────────────────────────────────────────
+
+  it("calls onOptimisticUpdate before the mutationFn fires", async () => {
+    const callOrder: string[] = [];
+    const mutationFn = vi.fn().mockImplementation(async () => {
+      callOrder.push("mutationFn");
+      return { ok: true };
+    });
+    const onOptimisticUpdate = vi.fn().mockImplementation(() => {
+      callOrder.push("onOptimisticUpdate");
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useApiMutation<{ ok: boolean }, void>(mutationFn, {
+          onOptimisticUpdate,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate(undefined as void);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(callOrder[0]).toBe("onOptimisticUpdate");
+    expect(callOrder[1]).toBe("mutationFn");
+  });
+
+  // ── onSuccess callback ─────────────────────────────────────────────────────
+
+  it("calls onSuccess with data and variables after a successful mutation", async () => {
+    const mockData = { id: "42" };
+    const mutationFn = vi.fn().mockResolvedValue(mockData);
+    const onSuccess = vi.fn();
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useApiMutation<typeof mockData, { name: string }>(mutationFn, {
+          onSuccess,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ name: "Max" });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(onSuccess).toHaveBeenCalledWith(mockData, { name: "Max" });
+  });
+
+  // ── mutateAsync ────────────────────────────────────────────────────────────
+
+  it("mutateAsync resolves with the returned data", async () => {
+    const mockData = { id: "99" };
+    const mutationFn = vi.fn().mockResolvedValue(mockData);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useApiMutation<typeof mockData, void>(mutationFn),
+      { wrapper },
+    );
+
+    let resolved: typeof mockData | undefined;
+    await act(async () => {
+      resolved = await result.current.mutateAsync(undefined as void);
+    });
+
+    expect(resolved).toEqual(mockData);
+  });
+
+  it("mutateAsync rejects when the mutation fails", async () => {
+    const apiError = new ApiError("Bad request", { status: 400 });
+    const mutationFn = vi.fn().mockRejectedValue(apiError);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useApiMutation<void, void>(mutationFn),
+      { wrapper },
+    );
+
+    await expect(
+      act(async () => {
+        await result.current.mutateAsync(undefined as void);
+      }),
+    ).rejects.toThrow("Bad request");
+  });
+});

--- a/src/hooks/useApiMutation.ts
+++ b/src/hooks/useApiMutation.ts
@@ -1,0 +1,140 @@
+import {
+  useMutation,
+  useQueryClient,
+  type MutationFunction,
+  type QueryKey,
+} from "@tanstack/react-query";
+import { ApiError } from "../lib/api-errors";
+
+export interface UseApiMutationOptions<TData, TVariables> {
+  /**
+   * Called before the mutation fires. Return the optimistic snapshot
+   * to be passed to onRollback if the mutation fails.
+   */
+  onOptimisticUpdate?: (variables: TVariables) => Promise<unknown> | unknown;
+
+  /**
+   * Called on error. Receives the snapshot returned by onOptimisticUpdate
+   * so you can restore previous cache state.
+   */
+  onRollback?: (snapshot: unknown, error: ApiError) => void;
+
+  /**
+   * Query keys whose cache entries should be invalidated on a successful
+   * mutation. Each element is either a full key array or a single-segment
+   * key that React Query will match with its default partial-matching logic.
+   */
+  invalidates?: QueryKey[];
+
+  /**
+   * Called after a successful mutation, before invalidation runs.
+   */
+  onSuccess?: (data: TData, variables: TVariables) => void;
+
+  /**
+   * Called when the mutation settles (success or error).
+   */
+  onSettled?: (
+    data: TData | undefined,
+    error: ApiError | null,
+    variables: TVariables,
+  ) => void;
+}
+
+export interface UseApiMutationReturn<TData, TVariables> {
+  mutate: (variables: TVariables) => void;
+  mutateAsync: (variables: TVariables) => Promise<TData>;
+  isPending: boolean;
+  isError: boolean;
+  error: ApiError | null;
+}
+
+/**
+ * A thin wrapper around useMutation with a consistent optimistic-update
+ * and rollback pattern.
+ *
+ * Flow:
+ *  1. onMutate  – cancel in-flight queries, snapshot cache, call
+ *                 onOptimisticUpdate so the caller can apply optimistic state.
+ *  2. onError   – restore snapshot via onRollback.
+ *  3. onSuccess – invalidate every query listed in options.invalidates[].
+ *
+ * @example
+ * const { mutate, isPending } = useApiMutation(
+ *   (data: CreatePetPayload) => petService.create(data),
+ *   {
+ *     invalidates: [['pets']],
+ *     onOptimisticUpdate: (variables) => {
+ *       const prev = queryClient.getQueryData(['pets']);
+ *       queryClient.setQueryData(['pets'], old => [...(old ?? []), variables]);
+ *       return prev; // snapshot
+ *     },
+ *     onRollback: (snapshot) => {
+ *       queryClient.setQueryData(['pets'], snapshot);
+ *     },
+ *   }
+ * );
+ */
+export function useApiMutation<TData, TVariables>(
+  mutationFn: MutationFunction<TData, TVariables>,
+  options?: UseApiMutationOptions<TData, TVariables>,
+): UseApiMutationReturn<TData, TVariables> {
+  const queryClient = useQueryClient();
+
+  const { mutate, mutateAsync, isPending, isError, error } = useMutation<
+    TData,
+    ApiError,
+    TVariables,
+    { snapshot: unknown }
+  >({
+    mutationFn,
+
+    onMutate: async (variables) => {
+      // Cancel any outgoing refetches so they don't overwrite optimistic state
+      if (options?.invalidates?.length) {
+        await Promise.all(
+          options.invalidates.map((key) =>
+            queryClient.cancelQueries({ queryKey: key }),
+          ),
+        );
+      }
+
+      // Let the caller apply optimistic state and capture a rollback snapshot
+      const snapshot = options?.onOptimisticUpdate
+        ? await options.onOptimisticUpdate(variables)
+        : undefined;
+
+      return { snapshot };
+    },
+
+    onError: (error, _variables, context) => {
+      // Restore previous cache state via caller-supplied rollback handler
+      if (options?.onRollback && context !== undefined) {
+        options.onRollback(context.snapshot, error);
+      }
+    },
+
+    onSuccess: (data, variables) => {
+      options?.onSuccess?.(data, variables);
+
+      // Invalidate every affected query key
+      if (options?.invalidates?.length) {
+        options.invalidates.forEach((key) => {
+          queryClient.invalidateQueries({ queryKey: key });
+        });
+      }
+    },
+
+    onSettled: (data, error, variables) => {
+      options?.onSettled?.(data, error, variables);
+    },
+  });
+
+  return {
+    mutate,
+    mutateAsync,
+    isPending,
+    isError,
+    error: error ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #101

Adds [useApiMutation](cci:1://file:///Users/mac/dev/drip3/PetAd-Frontend/src/hooks/useApiMutation.ts:51:0-139:1) — a thin, typed wrapper around TanStack Query's `useMutation` that enforces a consistent optimistic-update / rollback pattern across the app.

## Changes

- **[src/hooks/useApiMutation.ts](cci:7://file:///Users/mac/dev/drip3/PetAd-Frontend/src/hooks/useApiMutation.ts:0:0-0:0)** — new hook
- **[src/hooks/__tests__/useApiMutation.test.tsx](cci:7://file:///Users/mac/dev/drip3/PetAd-Frontend/src/hooks/__tests__/useApiMutation.test.tsx:0:0-0:0)** — 9 unit tests (all passing)

## How it works

```ts
const { mutate, mutateAsync, isPending, isError, error } = useApiMutation(
  (payload: CreatePetPayload) => petService.create(payload),
  {
    invalidates: [['pets']],
    onOptimisticUpdate: (variables) => {
      const prev = queryClient.getQueryData(['pets']);
      queryClient.setQueryData(['pets'], (old) => [...(old ?? []), variables]);
      return prev; // snapshot for rollback
    },
    onRollback: (snapshot) => {
      queryClient.setQueryData(['pets'], snapshot);
    },
  }
);
```

## Screenshot
<img width="975" height="236" alt="Screenshot 2026-03-25 at 4 10 30 AM" src="https://github.com/user-attachments/assets/bf5b5570-86af-4696-9531-f40af5967c17" />
