### PR TITLE
Create EscrowProgressStepper component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -450,6 +451,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -498,6 +500,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1808,8 +1811,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1879,6 +1881,7 @@
       "version": "24.10.15",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1887,6 +1890,7 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1895,6 +1899,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1938,6 +1943,7 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2298,6 +2304,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2334,7 +2341,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2364,7 +2370,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2432,6 +2437,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2615,7 +2621,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2632,8 +2637,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2733,6 +2737,7 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3544,7 +3549,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3714,6 +3718,7 @@
     "node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3761,7 +3766,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3777,7 +3781,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3796,6 +3799,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3803,6 +3807,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3815,8 +3820,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4153,6 +4157,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4238,6 +4243,7 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4513,6 +4519,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/ui/EscrowProgressStepper.tsx
+++ b/src/components/ui/EscrowProgressStepper.tsx
@@ -1,0 +1,171 @@
+import type { AdoptionStatus } from "../../types/adoption";
+
+interface EscrowProgressStepperProps {
+  currentStatus: AdoptionStatus;
+}
+
+interface StepDefinition {
+  key: string;
+  label: string;
+  status: AdoptionStatus;
+}
+
+const BASE_STEPS: StepDefinition[] = [
+  {
+    key: "ESCROW_CREATED",
+    label: "Escrow Created",
+    status: "ESCROW_CREATED",
+  },
+  {
+    key: "ESCROW_FUNDED",
+    label: "Escrow Funded",
+    status: "ESCROW_FUNDED",
+  },
+  {
+    key: "SETTLEMENT_TRIGGERED",
+    label: "Settlement Triggered",
+    status: "SETTLEMENT_TRIGGERED",
+  },
+  {
+    key: "FUNDS_RELEASED",
+    label: "Funds Released",
+    status: "FUNDS_RELEASED",
+  },
+];
+
+const DISPUTE_STEPS: StepDefinition[] = [
+  BASE_STEPS[0],
+  BASE_STEPS[1],
+  {
+    key: "DISPUTED",
+    label: "Dispute in Progress",
+    status: "DISPUTED",
+  },
+  BASE_STEPS[3],
+];
+
+const STATUS_ORDER: AdoptionStatus[] = [
+  "ESCROW_CREATED",
+  "ESCROW_FUNDED",
+  "SETTLEMENT_TRIGGERED",
+  "DISPUTED",
+  "FUNDS_RELEASED",
+];
+
+function getSteps(currentStatus: AdoptionStatus) {
+  return currentStatus === "DISPUTED" ? DISPUTE_STEPS : BASE_STEPS;
+}
+
+function getStepState(stepStatus: AdoptionStatus, currentStatus: AdoptionStatus) {
+  const currentIndex = STATUS_ORDER.indexOf(currentStatus);
+  const stepIndex = STATUS_ORDER.indexOf(stepStatus);
+
+  if (stepIndex < currentIndex) {
+    return "complete";
+  }
+
+  if (stepStatus === currentStatus) {
+    return "current";
+  }
+
+  return "upcoming";
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.5 8.25 6.5 11 12.5 5"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function EscrowProgressStepper({
+  currentStatus,
+}: EscrowProgressStepperProps) {
+  const steps = getSteps(currentStatus);
+
+  return (
+    <ol
+      role="list"
+      aria-label="Escrow settlement progress"
+      className="flex flex-col gap-4 rounded-3xl border border-[#E7EAF0] bg-white p-5 shadow-sm sm:flex-row sm:items-start sm:justify-between sm:gap-3"
+    >
+      {steps.map((step, index) => {
+        const state = getStepState(step.status, currentStatus);
+        const isCurrent = state === "current";
+        const isComplete = state === "complete";
+        const isUpcoming = state === "upcoming";
+
+        return (
+          <li
+            key={step.key}
+            aria-current={isCurrent ? "step" : undefined}
+            className="flex min-w-0 flex-1 items-start gap-3"
+          >
+            <div className="flex flex-1 items-start gap-3 sm:flex-col sm:items-center sm:text-center">
+              <div className="flex items-center">
+                <div
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border text-sm font-semibold transition-colors ${
+                    isComplete
+                      ? "border-[#E84D2A] bg-[#E84D2A] text-white"
+                      : isCurrent
+                        ? "border-[#E84D2A] bg-[#FFF1EC] text-[#B93817]"
+                        : "border-[#D7DEE8] bg-[#F7F9FC] text-[#90A0B7]"
+                  }`}
+                >
+                  {isComplete ? <CheckIcon /> : index + 1}
+                </div>
+
+                {index < steps.length - 1 ? (
+                  <div
+                    aria-hidden="true"
+                    className={`ml-3 hidden h-0.5 w-full min-w-8 rounded-full sm:block ${
+                      isComplete ? "bg-[#E84D2A]" : "bg-[#D7DEE8]"
+                    }`}
+                  />
+                ) : null}
+              </div>
+
+              <div className="flex-1 pt-1 sm:pt-0">
+                <p
+                  className={`text-sm font-semibold ${
+                    isComplete
+                      ? "text-[#0F2236]"
+                      : isCurrent
+                        ? "text-[#B93817]"
+                        : "text-[#8A97A8]"
+                  }`}
+                >
+                  {step.label}
+                </p>
+                <p
+                  className={`mt-1 text-xs ${
+                    isUpcoming ? "text-[#A5B1C2]" : "text-[#66758A]"
+                  }`}
+                >
+                  {isComplete
+                    ? "Completed"
+                    : isCurrent
+                      ? "Current step"
+                      : "Upcoming"}
+                </p>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/ui/__tests__/EscrowProgressStepper.test.tsx
+++ b/src/components/ui/__tests__/EscrowProgressStepper.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EscrowProgressStepper } from "../EscrowProgressStepper";
+
+function snapshotSteps(currentStatus: Parameters<typeof EscrowProgressStepper>[0]["currentStatus"]) {
+  const { unmount } = render(
+    <EscrowProgressStepper currentStatus={currentStatus} />
+  );
+
+  const steps = within(
+    screen.getByRole("list", { name: "Escrow settlement progress" })
+  )
+    .getAllByRole("listitem")
+    .map((step) => {
+      const lines = within(step).getAllByText(
+        (_content, element) => element?.tagName.toLowerCase() === "p"
+      );
+
+      return {
+        label: lines[0]?.textContent,
+        summary: lines[1]?.textContent,
+        current: step.getAttribute("aria-current") === "step",
+      };
+    });
+
+  unmount();
+  return steps;
+}
+
+describe("EscrowProgressStepper", () => {
+  it("matches the escrow created snapshot", () => {
+    expect(snapshotSteps("ESCROW_CREATED")).toMatchInlineSnapshot(`
+      [
+        {
+          "current": true,
+          "label": "Escrow Created",
+          "summary": "Current step",
+        },
+        {
+          "current": false,
+          "label": "Escrow Funded",
+          "summary": "Upcoming",
+        },
+        {
+          "current": false,
+          "label": "Settlement Triggered",
+          "summary": "Upcoming",
+        },
+        {
+          "current": false,
+          "label": "Funds Released",
+          "summary": "Upcoming",
+        },
+      ]
+    `);
+  });
+
+  it("matches the escrow funded snapshot", () => {
+    expect(snapshotSteps("ESCROW_FUNDED")).toMatchInlineSnapshot(`
+      [
+        {
+          "current": false,
+          "label": "Escrow Created",
+          "summary": "Completed",
+        },
+        {
+          "current": true,
+          "label": "Escrow Funded",
+          "summary": "Current step",
+        },
+        {
+          "current": false,
+          "label": "Settlement Triggered",
+          "summary": "Upcoming",
+        },
+        {
+          "current": false,
+          "label": "Funds Released",
+          "summary": "Upcoming",
+        },
+      ]
+    `);
+  });
+
+  it("matches the settlement triggered snapshot", () => {
+    expect(snapshotSteps("SETTLEMENT_TRIGGERED")).toMatchInlineSnapshot(`
+      [
+        {
+          "current": false,
+          "label": "Escrow Created",
+          "summary": "Completed",
+        },
+        {
+          "current": false,
+          "label": "Escrow Funded",
+          "summary": "Completed",
+        },
+        {
+          "current": true,
+          "label": "Settlement Triggered",
+          "summary": "Current step",
+        },
+        {
+          "current": false,
+          "label": "Funds Released",
+          "summary": "Upcoming",
+        },
+      ]
+    `);
+  });
+
+  it("matches the disputed snapshot", () => {
+    expect(snapshotSteps("DISPUTED")).toMatchInlineSnapshot(`
+      [
+        {
+          "current": false,
+          "label": "Escrow Created",
+          "summary": "Completed",
+        },
+        {
+          "current": false,
+          "label": "Escrow Funded",
+          "summary": "Completed",
+        },
+        {
+          "current": true,
+          "label": "Dispute in Progress",
+          "summary": "Current step",
+        },
+        {
+          "current": false,
+          "label": "Funds Released",
+          "summary": "Upcoming",
+        },
+      ]
+    `);
+  });
+
+  it("matches the funds released snapshot", () => {
+    expect(snapshotSteps("FUNDS_RELEASED")).toMatchInlineSnapshot(`
+      [
+        {
+          "current": false,
+          "label": "Escrow Created",
+          "summary": "Completed",
+        },
+        {
+          "current": false,
+          "label": "Escrow Funded",
+          "summary": "Completed",
+        },
+        {
+          "current": false,
+          "label": "Settlement Triggered",
+          "summary": "Completed",
+        },
+        {
+          "current": true,
+          "label": "Funds Released",
+          "summary": "Current step",
+        },
+      ]
+    `);
+  });
+
+  it("marks the active step with aria-current", () => {
+    render(<EscrowProgressStepper currentStatus="SETTLEMENT_TRIGGERED" />);
+
+    const activeStep = screen.getByText("Settlement Triggered").closest("li");
+
+    expect(activeStep?.getAttribute("aria-current")).toBe("step");
+  });
+
+  it("shows the dispute interstitial only for disputed status", () => {
+    const { rerender } = render(
+      <EscrowProgressStepper currentStatus="DISPUTED" />
+    );
+
+    expect(screen.getByText("Dispute in Progress")).toBeTruthy();
+
+    rerender(<EscrowProgressStepper currentStatus="FUNDS_RELEASED" />);
+
+    expect(screen.queryByText("Dispute in Progress")).toBeNull();
+  });
+});

--- a/src/types/adoption.ts
+++ b/src/types/adoption.ts
@@ -1,0 +1,6 @@
+export type AdoptionStatus =
+  | "ESCROW_CREATED"
+  | "ESCROW_FUNDED"
+  | "SETTLEMENT_TRIGGERED"
+  | "DISPUTED"
+  | "FUNDS_RELEASED";


### PR DESCRIPTION
close #117 

Add a shared AdoptionStatus type so the stepper prop is concrete instead of a loose string.
Build EscrowProgressStepper as an accessible list with completed/current/future states and the dispute interstitial branch.
Add snapshot coverage for the meaningful lifecycle states the ticket names, plus a small behavior check for aria-current.
Run the relevant test/build command and tighten anything TypeScript or snapshots complain about.

 you can run "npm" run dev to check 

but for more emphasis on the component i created, run ".\node_modules\.bin\vitest.cmd run src/components/ui/__tests__/EscrowProgressStepper.test.tsx" and it should some something like this below 


 RUN  v4.1.1 C:/Users/User/Desktop/PetAd-Frontend

 ✓ src/components/ui/__tests__/EscrowProgressStepper.test.tsx (7 tests) 372ms
   ✓ EscrowProgressStepper (7)
     ✓ matches the escrow created snapshot 248ms
     ✓ matches the escrow funded snapshot 31ms
     ✓ matches the settlement triggered snapshot 24ms
     ✓ matches the disputed snapshot 20ms
     ✓ matches the funds released snapshot 20ms
     ✓ marks the active step with aria-current 10ms
     ✓ shows the dispute interstitial only for disputed status 15ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  16:07:33
   Duration  2.57s (transform 90ms, setup 292ms, import 66ms, tests 372ms, environment 1.58s)
