### PR TITLE
feat(ui): add EmptyState component

### DIFF
--- a/src/components/ui/__tests__/emptyState.test.tsx
+++ b/src/components/ui/__tests__/emptyState.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { EmptyState } from "../emptyState";
+
+describe("EmptyState", () => {
+  it("renders title and description", () => {
+    render(
+      <EmptyState
+        title="No settlements yet"
+        description="Settlement data will appear once the escrow is triggered."
+      />,
+    );
+
+    expect(screen.getByText("No settlements yet")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Settlement data will appear once the escrow is triggered.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders the action button when action prop is provided", () => {
+    const onClick = vi.fn();
+
+    render(
+      <EmptyState
+        title="Nothing here"
+        description="Try again later."
+        action={{ label: "Retry", onClick }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Retry" });
+    expect(button).toBeTruthy();
+  });
+
+  it("calls onClick when the action button is clicked", () => {
+    const onClick = vi.fn();
+
+    render(
+      <EmptyState
+        title="Nothing here"
+        description="Try again later."
+        action={{ label: "Retry", onClick }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a button when action prop is omitted", () => {
+    render(
+      <EmptyState
+        title="Nothing here"
+        description="No action needed."
+      />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("has role='status' and aria-label set to the title", () => {
+    render(
+      <EmptyState
+        title="Empty queue"
+        description="Queue is currently empty."
+      />,
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toBeTruthy();
+    expect(region.getAttribute("aria-label")).toBe("Empty queue");
+  });
+});

--- a/src/components/ui/emptyState.tsx
+++ b/src/components/ui/emptyState.tsx
@@ -1,0 +1,68 @@
+type EmptyStateAction = {
+  label: string;
+  onClick: () => void;
+};
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  action?: EmptyStateAction;
+};
+
+/**
+ * Consistent empty state display used when lists, queues, and pages have no data.
+ *
+ * @example
+ * <EmptyState
+ *   title="No settlements yet"
+ *   description="Settlement data will appear here once the escrow is triggered."
+ *   action={{ label: "Refresh", onClick: refetch }}
+ * />
+ */
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      aria-label={title}
+      className="flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-gray-200 bg-gray-50 px-6 py-12 text-center"
+    >
+      {/* Icon area */}
+      <div
+        aria-hidden="true"
+        className="flex h-14 w-14 items-center justify-center rounded-full bg-gray-100"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-7 w-7 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M20 13V7a2 2 0 00-2-2H6a2 2 0 00-2 2v6m16 0v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4m16 0H4"
+          />
+        </svg>
+      </div>
+
+      {/* Text */}
+      <div className="space-y-1">
+        <p className="text-base font-semibold text-gray-900">{title}</p>
+        <p className="text-sm text-gray-500">{description}</p>
+      </div>
+
+      {/* Optional action */}
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          className="mt-2 rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a reusable `EmptyState` component for consistent empty state display
across lists, queues, and pages that have no data.

## Changes

### New: `src/[components folder]/EmptyState.tsx`
- Accepts `title`, `description`, and optional `action?: { label, onClick }` props
- Renders icon area, title, description, and an optional action button
- Accessible: `role="status"` with `aria-label` set to the title value
- Action button only renders when the `action` prop is provided

### New: `src/[components folder]/EmptyState.test.tsx`
- Renders title and description correctly
- Renders action button when `action` prop is provided
- Calls `onClick` when action button is clicked
- Does not render a button when `action` prop is omitted
- Confirms `role="status"` and `aria-label` are set correctly

## Notes
- Styling uses Tailwind and matches the existing orange accent color
  used across the escrow UI components
- No changes to any existing files

Closes #109