### PR TITLE
feat: add CopyToClipboard reusable component

### DIFF
--- a/src/components/ui/CopyToClipboard.tsx
+++ b/src/components/ui/CopyToClipboard.tsx
@@ -1,0 +1,63 @@
+import { useState, useRef, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyToClipboardProps {
+  value: string;
+  children: ReactNode;
+}
+
+export function CopyToClipboard({ value, children }: CopyToClipboardProps) {
+  const [isCopied, setIsCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setIsCopied(true);
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error('Failed to copy to clipboard:', error);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label="Copy to clipboard"
+      className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-sm transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+        isCopied
+          ? 'bg-green-50 text-green-600 border border-green-200 focus:ring-green-500'
+          : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 active:scale-95 focus:ring-[#E84D2A]'
+      }`}
+    >
+      {isCopied ? (
+        <>
+          <Check size={16} />
+          <span>Copied!</span>
+        </>
+      ) : (
+        <>
+          <Copy size={16} />
+          <span>{children}</span>
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## 🎯 Description
Adds a reusable CopyToClipboard component for copying text to clipboard with visual feedback.

## Related Issue
Closes #107 

## Changes
Copies text to clipboard using `navigator.clipboard.writeText()`
Shows "Copied!" feedback for 2 seconds then auto-reverts
Accessible with `aria-label="Copy to clipboard"`

##Testing 
To check what's been newly added, use the below code to visualize the changes made

"
    <div>
      <h1>Test Copy to Clipboard</h1>
      
      <CopyToClipboard value="https://example.com/adoption/123">
        Copy Link
      </CopyToClipboard>

      <CopyToClipboard value="pet-123-code">
        Copy Pet Code
      </CopyToClipboard>
    </div>
 
" 
