### PR TITLE
feat: add AdoptionStatusBadge with tooltip and snapshot tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -439,7 +438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -484,7 +482,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2009,7 +2006,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2142,7 +2140,6 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2161,7 +2158,6 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2230,7 +2226,6 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2577,7 +2572,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2702,7 +2696,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2961,7 +2954,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3064,7 +3058,6 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4116,6 +4109,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4163,7 +4157,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -4409,6 +4402,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4422,6 +4416,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4457,7 +4452,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4478,7 +4472,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4489,7 +4482,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4960,7 +4954,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5054,7 +5047,6 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5381,7 +5373,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/ui/AdoptionStatusBadge.tsx
+++ b/src/components/ui/AdoptionStatusBadge.tsx
@@ -1,0 +1,75 @@
+import type { AdoptionStatus } from '../../types/adoption'
+
+interface AdoptionStatusBadgeProps {
+  status: AdoptionStatus | string
+}
+
+const STATUS_CONFIG: Record<string, {
+  label: string
+  textClass: string
+  bgClass: string
+  tooltip: string
+}> = {
+  ESCROW_CREATED: {
+    label: 'Escrow Created',
+    textClass: 'text-gray-700',
+    bgClass: 'bg-gray-100',
+    tooltip: 'Escrow has been created but not funded yet.',
+  },
+  ESCROW_FUNDED: {
+    label: 'Escrow Funded',
+    textClass: 'text-teal-700',
+    bgClass: 'bg-teal-100',
+    tooltip: 'Funds have been deposited into escrow.',
+  },
+  SETTLEMENT_TRIGGERED: {
+    label: 'Settlement Triggered',
+    textClass: 'text-amber-700',
+    bgClass: 'bg-amber-100',
+    tooltip: 'Settlement process has started.',
+  },
+  CUSTODY_ACTIVE: {
+    label: 'Custody Active',
+    textClass: 'text-green-700',
+    bgClass: 'bg-green-100',
+    tooltip: 'Pet custody is currently active.',
+  },
+  FUNDS_RELEASED: {
+    label: 'Funds Released',
+    textClass: 'text-green-700',
+    bgClass: 'bg-green-100',
+    tooltip: 'Funds have been released successfully.',
+  },
+  DISPUTED: {
+    label: 'Disputed',
+    textClass: 'text-red-700',
+    bgClass: 'bg-red-100',
+    tooltip: 'There is a dispute in the adoption.',
+  },
+  NOT_FOUND: {
+    label: 'Not Found',
+    textClass: 'text-gray-700',
+    bgClass: 'bg-gray-100',
+    tooltip: 'Unknown adoption status.',
+  },
+}
+
+export function AdoptionStatusBadge({ status }: AdoptionStatusBadgeProps) {
+  const config = STATUS_CONFIG[status] || STATUS_CONFIG.NOT_FOUND
+
+  return (
+    <div className="relative group inline-block">
+      <span
+        className={`px-2 py-1 text-xs font-medium rounded-full ${config.textClass} ${config.bgClass}`}
+      >
+        {config.label}
+      </span>
+
+      <div className="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block">
+        <div className="rounded-md bg-black text-white text-xs px-2 py-1">
+          {config.tooltip}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/__tests__/AdoptionStatusBadge.test.tsx
+++ b/src/components/ui/__tests__/AdoptionStatusBadge.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AdoptionStatusBadge } from '../AdoptionStatusBadge'
+
+const cases = [
+  { status: 'ESCROW_CREATED', label: 'Escrow Created', textClass: 'text-gray-700' },
+  { status: 'ESCROW_FUNDED', label: 'Escrow Funded', textClass: 'text-teal-700' },
+  { status: 'SETTLEMENT_TRIGGERED', label: 'Settlement Triggered', textClass: 'text-amber-700' },
+  { status: 'CUSTODY_ACTIVE', label: 'Custody Active', textClass: 'text-green-700' },
+  { status: 'FUNDS_RELEASED', label: 'Funds Released', textClass: 'text-green-700' },
+  { status: 'DISPUTED', label: 'Disputed', textClass: 'text-red-700' },
+]
+
+describe('AdoptionStatusBadge', () => {
+  it.each(cases)('renders $status correctly', ({ status, label, textClass }) => {
+    const { container } = render(<AdoptionStatusBadge status={status} />)
+
+    const pill = screen.getByText(label)
+    expect(pill).toBeTruthy()
+
+    expect(pill.className).toContain(textClass)
+
+    const tooltip = container.querySelector('[class*="rounded-md"]')
+    expect(tooltip).not.toBeNull()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('fallback works', () => {
+    render(<AdoptionStatusBadge status="UNKNOWN" />)
+    expect(screen.getByText('Not Found')).toBeTruthy()
+  })
+})

--- a/src/components/ui/__tests__/__snapshots__/AdoptionStatusBadge.test.tsx.snap
+++ b/src/components/ui/__tests__/__snapshots__/AdoptionStatusBadge.test.tsx.snap
@@ -1,0 +1,139 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AdoptionStatusBadge > renders 'CUSTODY_ACTIVE' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-green-700 bg-green-100"
+    >
+      Custody Active
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        Pet custody is currently active.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'DISPUTED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-red-700 bg-red-100"
+    >
+      Disputed
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        There is a dispute in the adoption.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'ESCROW_CREATED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-gray-700 bg-gray-100"
+    >
+      Escrow Created
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        Escrow has been created but not funded yet.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'ESCROW_FUNDED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-teal-700 bg-teal-100"
+    >
+      Escrow Funded
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        Funds have been deposited into escrow.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'FUNDS_RELEASED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-green-700 bg-green-100"
+    >
+      Funds Released
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        Funds have been released successfully.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'SETTLEMENT_TRIGGERED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-amber-700 bg-amber-100"
+    >
+      Settlement Triggered
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        Settlement process has started.
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Implemented AdoptionStatusBadge component with:

- Status → color and label mapping
- Tooltip with plain-English descriptions
- Snapshot tests for all statuses
- Fallback handling for unknown status

Note:
Used actual AdoptionStatus enum from codebase instead of issue description values (issue description seems outdated).

Follows same pattern as EscrowStatusBadge for consistency.  
close #149 