### PR TITLE
test: cover status polling and terminal badge states

### DIFF
--- a/src/components/ui/AdoptionStatusBadge.tsx
+++ b/src/components/ui/AdoptionStatusBadge.tsx
@@ -40,6 +40,18 @@ const STATUS_CONFIG: Record<string, {
     bgClass: 'bg-green-100',
     tooltip: 'Funds have been released successfully.',
   },
+  COMPLETED: {
+    label: 'Completed',
+    textClass: 'text-emerald-700',
+    bgClass: 'bg-emerald-100',
+    tooltip: 'The adoption lifecycle has been completed.',
+  },
+  CANCELLED: {
+    label: 'Cancelled',
+    textClass: 'text-slate-700',
+    bgClass: 'bg-slate-100',
+    tooltip: 'The adoption was cancelled before completion.',
+  },
   DISPUTED: {
     label: 'Disputed',
     textClass: 'text-red-700',

--- a/src/components/ui/__tests__/AdoptionStatusBadge.test.tsx
+++ b/src/components/ui/__tests__/AdoptionStatusBadge.test.tsx
@@ -8,6 +8,8 @@ const cases = [
   { status: 'SETTLEMENT_TRIGGERED', label: 'Settlement Triggered', textClass: 'text-amber-700' },
   { status: 'CUSTODY_ACTIVE', label: 'Custody Active', textClass: 'text-green-700' },
   { status: 'FUNDS_RELEASED', label: 'Funds Released', textClass: 'text-green-700' },
+  { status: 'COMPLETED', label: 'Completed', textClass: 'text-emerald-700' },
+  { status: 'CANCELLED', label: 'Cancelled', textClass: 'text-slate-700' },
   { status: 'DISPUTED', label: 'Disputed', textClass: 'text-red-700' },
 ]
 

--- a/src/components/ui/__tests__/__snapshots__/AdoptionStatusBadge.test.tsx.snap
+++ b/src/components/ui/__tests__/__snapshots__/AdoptionStatusBadge.test.tsx.snap
@@ -1,5 +1,51 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`AdoptionStatusBadge > renders 'CANCELLED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-slate-700 bg-slate-100"
+    >
+      Cancelled
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        The adoption was cancelled before completion.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`AdoptionStatusBadge > renders 'COMPLETED' correctly 1`] = `
+<div>
+  <div
+    class="relative group inline-block"
+  >
+    <span
+      class="px-2 py-1 text-xs font-medium rounded-full text-emerald-700 bg-emerald-100"
+    >
+      Completed
+    </span>
+    <div
+      class="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block"
+    >
+      <div
+        class="rounded-md bg-black text-white text-xs px-2 py-1"
+      >
+        The adoption lifecycle has been completed.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`AdoptionStatusBadge > renders 'CUSTODY_ACTIVE' correctly 1`] = `
 <div>
   <div

--- a/src/lib/hooks/__tests__/useRealTimeStatusPolling.simple.test.tsx
+++ b/src/lib/hooks/__tests__/useRealTimeStatusPolling.simple.test.tsx
@@ -55,6 +55,7 @@ describe("useRealTimeStatusPolling - Simple Tests", () => {
 
     expect(mockGetDetails).toHaveBeenCalledWith("adoption-1");
     expect(mockGetDetails).toHaveBeenCalledTimes(1);
+    expect(result.current.statusChanged).toBe(false);
   });
 
   it("should throw error for invalid entity type", () => {

--- a/src/lib/hooks/__tests__/useRealTimeStatusPolling.test.tsx
+++ b/src/lib/hooks/__tests__/useRealTimeStatusPolling.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useRealTimeStatusPolling } from "../useRealTimeStatusPolling";
@@ -48,12 +48,8 @@ const mockCustodyData: CustodyDetails = {
 };
 
 describe("useRealTimeStatusPolling", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-  });
-
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -69,17 +65,15 @@ describe("useRealTimeStatusPolling", () => {
       { wrapper: createWrapper(queryClient) }
     );
 
-    // Initial fetch
-    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(1));
-    expect(result.current.data).toEqual(mockAdoptionData);
-
-    // Fast-forward 100ms
-    act(() => {
-      vi.advanceTimersByTime(100);
+    await waitFor(() => {
+      expect(mockGetDetails).toHaveBeenCalledTimes(1);
+      expect(result.current.data).toEqual(mockAdoptionData);
+      expect(result.current.statusChanged).toBe(false);
     });
 
-    // Should poll again
-    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
+    });
   });
 
   it("polls custody details when entityType is custody", async () => {
@@ -93,12 +87,16 @@ describe("useRealTimeStatusPolling", () => {
       { wrapper: createWrapper(queryClient) }
     );
 
-    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(1));
-    expect(mockGetDetails).toHaveBeenCalledWith("custody-1");
-    expect(result.current.data).toEqual(mockCustodyData);
+    await waitFor(() => {
+      expect(mockGetDetails).toHaveBeenCalledTimes(1);
+      expect(mockGetDetails).toHaveBeenCalledWith("custody-1");
+      expect(result.current.data).toEqual(mockCustodyData);
+    });
   });
 
-  it("sets statusChanged to true for 3 seconds after status change", async () => {
+  it(
+    "sets statusChanged to true for 3 seconds after status change",
+    async () => {
     const queryClient = createTestQueryClient();
     vi
       .spyOn(adoptionService.adoptionService, "getDetails")
@@ -109,33 +107,28 @@ describe("useRealTimeStatusPolling", () => {
       });
 
     const { result } = renderHook(
-      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 100 }),
+      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 25 }),
       { wrapper: createWrapper(queryClient) }
     );
 
-    // Initial state - no status change
+    await waitFor(() => {
+      expect(result.current.data?.status).toBe("ESCROW_CREATED");
+      expect(result.current.statusChanged).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.status).toBe("ESCROW_FUNDED");
+      expect(result.current.statusChanged).toBe(true);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3100));
+    });
+
     await waitFor(() => expect(result.current.statusChanged).toBe(false));
-
-    // Trigger status change
-    act(() => {
-      vi.advanceTimersByTime(100);
-    });
-
-    // Status should have changed
-    await waitFor(() => expect(result.current.statusChanged).toBe(true));
-
-    // After 2 seconds, still true
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-    expect(result.current.statusChanged).toBe(true);
-
-    // After 3 seconds total, should be false
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-    expect(result.current.statusChanged).toBe(false);
-  });
+    },
+    8000,
+  );
 
   it("stops polling when status is COMPLETED", async () => {
     const queryClient = createTestQueryClient();
@@ -148,26 +141,20 @@ describe("useRealTimeStatusPolling", () => {
       });
 
     renderHook(
-      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 100 }),
+      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 25 }),
       { wrapper: createWrapper(queryClient) }
     );
 
-    // Initial fetch
     await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(1));
 
-    // Status changes to COMPLETED
-    act(() => {
-      vi.advanceTimersByTime(100);
+    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
     });
 
-    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2));
-
-    // Fast-forward another 100ms - should not poll again
-    act(() => {
-      vi.advanceTimersByTime(100);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
     });
 
-    // Should still be 2 calls (polling stopped)
     expect(mockGetDetails).toHaveBeenCalledTimes(2);
   });
 
@@ -182,26 +169,20 @@ describe("useRealTimeStatusPolling", () => {
       });
 
     renderHook(
-      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 100 }),
+      () => useRealTimeStatusPolling("adoption", "adoption-1", { intervalMs: 25 }),
       { wrapper: createWrapper(queryClient) }
     );
 
-    // Initial fetch
     await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(1));
 
-    // Status changes to CANCELLED
-    act(() => {
-      vi.advanceTimersByTime(100);
+    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2), {
+      timeout: 1000,
     });
 
-    await waitFor(() => expect(mockGetDetails).toHaveBeenCalledTimes(2));
-
-    // Fast-forward another 100ms - should not poll again
-    act(() => {
-      vi.advanceTimersByTime(100);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
     });
 
-    // Should still be 2 calls (polling stopped)
     expect(mockGetDetails).toHaveBeenCalledTimes(2);
   });
 

--- a/src/lib/hooks/useRealTimeStatusPolling.ts
+++ b/src/lib/hooks/useRealTimeStatusPolling.ts
@@ -5,6 +5,7 @@ import { custodyService } from "../../api/custodyService";
 import type { AdoptionDetails, CustodyDetails } from "../../types/adoption";
 
 type EntityType = "adoption" | "custody";
+const SUPPORTED_ENTITY_TYPES = ["adoption", "custody"] as const;
 
 export interface UseRealTimeStatusPollingOptions {
   intervalMs?: number;
@@ -15,6 +16,10 @@ export function useRealTimeStatusPolling(
   entityId: string,
   options: UseRealTimeStatusPollingOptions = {},
 ) {
+  if (!SUPPORTED_ENTITY_TYPES.includes(entityType)) {
+    throw new Error(`Unsupported entity type: ${entityType}`);
+  }
+
   const { intervalMs = 15000 } = options;
   const [statusChanged, setStatusChanged] = useState(false);
   const previousStatusRef = useRef<string | undefined>(undefined);
@@ -26,8 +31,6 @@ export function useRealTimeStatusPolling(
         return adoptionService.getDetails(entityId);
       case "custody":
         return custodyService.getDetails(entityId);
-      default:
-        throw new Error(`Unsupported entity type: ${entityType}`);
     }
   };
 
@@ -46,17 +49,22 @@ export function useRealTimeStatusPolling(
   useEffect(() => {
     const currentStatus = query.data?.status;
 
-    if (currentStatus && previousStatusRef.current !== currentStatus) {
-      // Status has changed
-      setStatusChanged(true);
+    if (!currentStatus) {
+      return;
+    }
 
-      // Reset after 3 seconds
+    if (previousStatusRef.current === undefined) {
+      previousStatusRef.current = currentStatus;
+      return;
+    }
+
+    if (previousStatusRef.current !== currentStatus) {
+      setStatusChanged(true);
+      previousStatusRef.current = currentStatus;
+
       const timer = setTimeout(() => {
         setStatusChanged(false);
       }, 3000);
-
-      // Update previous status
-      previousStatusRef.current = currentStatus;
 
       return () => clearTimeout(timer);
     }


### PR DESCRIPTION
This pull request adds support for two new adoption statuses, "COMPLETED" and "CANCELLED", in the UI and updates the real-time status polling hook and its tests for improved reliability and correctness. The changes include new status badge configurations, updated tests and snapshots, stricter entity type validation, and more robust status change detection logic.

**Adoption Status Badge Enhancements:**
- Added support for "COMPLETED" and "CANCELLED" statuses in the `AdoptionStatusBadge` component, including their labels, colors, and tooltips.
- Updated tests and snapshots to cover rendering and display of the new statuses. [[1]](diffhunk://#diff-39e1c8560b3fc1be1d0b28cf5c0693d92dfdeafe4ec4ef76a4091a297b7e5257R11-R12) [[2]](diffhunk://#diff-2418ad0ea617a3e66436cae42831e065e496d39400ee0b1aedbca50a2c9fa72dR3-R48)

**Real-Time Status Polling Improvements:**
- Added validation for supported entity types in `useRealTimeStatusPolling`, throwing an error for unsupported types. [[1]](diffhunk://#diff-baca63a5cece3d0ed55720802d0cbcc9dc3c677c280086f4a842d110ba9e7dbcR8) [[2]](diffhunk://#diff-baca63a5cece3d0ed55720802d0cbcc9dc3c677c280086f4a842d110ba9e7dbcR19-R22) [[3]](diffhunk://#diff-baca63a5cece3d0ed55720802d0cbcc9dc3c677c280086f4a842d110ba9e7dbcL29-L30)
- Improved status change detection logic to avoid false positives on the initial fetch and ensure correct handling of status transitions.

**Testing Enhancements:**
- Expanded and refactored tests for `useRealTimeStatusPolling` to check for correct status change handling, polling behavior, and error cases. [[1]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L1-R1) [[2]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L51-R52) [[3]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L72-R76) [[4]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L96-R99) [[5]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L112-R132) [[6]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L151-L170) [[7]](diffhunk://#diff-050bccf27a4d2c7acca9d95db1d2de594935199f76c9d03dbc34eb8b35d3b932L185-L204) [[8]](diffhunk://#diff-aa2c6d8e609f6a1222119894333561a53636bf77970a126d482aeaa1c4d9c437R58)

Closes #163