### PR TITLE
Add adoption status filters to requests list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -438,6 +439,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -482,6 +484,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2006,8 +2009,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2140,6 +2142,7 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2158,6 +2161,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2226,6 +2230,7 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2572,6 +2577,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2696,6 +2702,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2954,8 +2961,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -3058,6 +3064,7 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4109,7 +4116,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4157,6 +4163,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -4402,7 +4409,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4416,7 +4422,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4452,6 +4457,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4472,6 +4478,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4482,8 +4489,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4954,6 +4960,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5047,6 +5054,7 @@
     "node_modules/vite": {
       "version": "7.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5373,6 +5381,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/api/adoptionService.ts
+++ b/src/api/adoptionService.ts
@@ -1,5 +1,10 @@
 import { apiClient } from "../lib/api-client";
-import type { AdoptionTimelineEntry, AdoptionDetails } from "../types/adoption";
+import type {
+  AdoptionTimelineEntry,
+  AdoptionDetails,
+  AdoptionRequest,
+  AdoptionStatus,
+} from "../types/adoption";
 
 export interface AdoptionRating {
   rating: number;
@@ -8,7 +13,24 @@ export interface AdoptionRating {
   petId?: string;
 }
 
+export interface GetAdoptionListParams {
+  status?: AdoptionStatus[];
+}
+
 export const adoptionService = {
+  async getList(params: GetAdoptionListParams = {}): Promise<AdoptionRequest[]> {
+    const searchParams = new URLSearchParams();
+
+    params.status?.forEach((status) => {
+      searchParams.append("status", status);
+    });
+
+    const query = searchParams.toString();
+    const endpoint = `/adoption/requests${query ? `?${query}` : ""}`;
+
+    return apiClient.get(endpoint);
+  },
+
   async getDetails(adoptionId: string): Promise<AdoptionDetails> {
     return apiClient.get(`/adoption/${adoptionId}`);
   },

--- a/src/components/ui/AdoptionStatusBadge.tsx
+++ b/src/components/ui/AdoptionStatusBadge.tsx
@@ -46,6 +46,18 @@ const STATUS_CONFIG: Record<string, {
     bgClass: 'bg-red-100',
     tooltip: 'There is a dispute in the adoption.',
   },
+  COMPLETED: {
+    label: 'Completed',
+    textClass: 'text-emerald-700',
+    bgClass: 'bg-emerald-100',
+    tooltip: 'The adoption has been completed.',
+  },
+  CANCELLED: {
+    label: 'Cancelled',
+    textClass: 'text-slate-700',
+    bgClass: 'bg-slate-100',
+    tooltip: 'The adoption was cancelled.',
+  },
   NOT_FOUND: {
     label: 'Not Found',
     textClass: 'text-gray-700',

--- a/src/components/ui/StatusFilterChips.tsx
+++ b/src/components/ui/StatusFilterChips.tsx
@@ -1,0 +1,58 @@
+import type { AdoptionStatus } from "../../types/adoption";
+
+interface StatusFilterChipsProps {
+  options: AdoptionStatus[];
+  selectedStatuses: AdoptionStatus[];
+  counts?: Partial<Record<AdoptionStatus, number>>;
+  onToggle: (status: AdoptionStatus) => void;
+}
+
+const STATUS_LABELS: Record<AdoptionStatus, string> = {
+  ESCROW_CREATED: "Escrow Created",
+  ESCROW_FUNDED: "Escrow Funded",
+  SETTLEMENT_TRIGGERED: "Settlement Triggered",
+  DISPUTED: "Disputed",
+  FUNDS_RELEASED: "Funds Released",
+  CUSTODY_ACTIVE: "Custody Active",
+  COMPLETED: "Completed",
+  CANCELLED: "Cancelled",
+};
+
+export function formatAdoptionStatusLabel(status: AdoptionStatus) {
+  return STATUS_LABELS[status];
+}
+
+export function StatusFilterChips({
+  options,
+  selectedStatuses,
+  counts,
+  onToggle,
+}: StatusFilterChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-3" aria-label="Adoption status filters">
+      {options.map((status) => {
+        const isActive = selectedStatuses.includes(status);
+        const count = counts?.[status];
+        const label = formatAdoptionStatusLabel(status);
+        const chipLabel = isActive && typeof count === "number" ? `${label} (${count})` : label;
+
+        return (
+          <button
+            key={status}
+            type="button"
+            onClick={() => onToggle(status)}
+            aria-pressed={isActive}
+            className={[
+              "rounded-full border px-4 py-2 text-sm font-medium transition-colors",
+              isActive
+                ? "border-[#E84D2A] bg-[#FFF1ED] text-[#B93815]"
+                : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:text-gray-900",
+            ].join(" ")}
+          >
+            {chipLabel}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useAdoptionList.ts
+++ b/src/hooks/useAdoptionList.ts
@@ -1,0 +1,16 @@
+import { adoptionService } from "../api/adoptionService";
+import { useApiQuery } from "./useApiQuery";
+import type { AdoptionRequest, AdoptionStatus } from "../types/adoption";
+
+interface UseAdoptionListParams {
+  status?: AdoptionStatus[];
+}
+
+export function useAdoptionList(params: UseAdoptionListParams = {}) {
+  const normalizedStatuses = [...(params.status ?? [])].sort();
+
+  return useApiQuery<AdoptionRequest[]>(
+    ["adoption-requests", normalizedStatuses],
+    () => adoptionService.getList({ status: normalizedStatuses }),
+  );
+}

--- a/src/mocks/handlers/adoption.ts
+++ b/src/mocks/handlers/adoption.ts
@@ -2,29 +2,42 @@ import { http, HttpResponse, delay } from "msw";
 import type {
   AdoptionTimelineEntry,
   AdoptionDetails,
+  AdoptionRequest,
 } from "../../types/adoption";
 
-const MOCK_TIMELINE: TimelineEntry[] = [
+const MOCK_TIMELINE: AdoptionTimelineEntry[] = [
   {
+    id: "timeline-1",
+    adoptionId: "adoption-1",
+    timestamp: "2026-03-25T10:00:00Z",
+    sdkEvent: "ADOPTION_REQUESTED",
+    message: "Adoption request created",
+    actor: "System",
     fromStatus: null,
     toStatus: "ESCROW_CREATED",
-    actor: "System",
-    timestamp: "2026-03-25T10:00:00Z",
     reason: "Initial adoption request",
   },
   {
+    id: "timeline-2",
+    adoptionId: "adoption-1",
+    timestamp: "2026-03-25T11:30:00Z",
+    sdkEvent: "ESCROW_FUNDED",
+    message: "Escrow funded successfully",
+    actor: "Adopter",
     fromStatus: "ESCROW_CREATED",
     toStatus: "ESCROW_FUNDED",
-    actor: "Adopter",
-    timestamp: "2026-03-25T11:30:00Z",
     sdkTxHash: "0x1234...5678",
-    stellarExplorerUrl: "https://stellar.expert/explorer/public/tx/1234",
   },
+
   {
+    id: "timeline-3",
+    adoptionId: "adoption-1",
+    timestamp: "2026-03-26T09:15:00Z",
+    sdkEvent: "SETTLEMENT_TRIGGERED",
+    message: "Settlement triggered",
+    actor: "System",
     fromStatus: "ESCROW_FUNDED",
     toStatus: "SETTLEMENT_TRIGGERED",
-    actor: "System",
-    timestamp: "2026-03-26T09:15:00Z",
     reason: "Auto-settlement after inspection",
   },
 ];
@@ -38,7 +51,89 @@ const MOCK_ADOPTION_DETAILS: AdoptionDetails = {
   updatedAt: "2026-03-25T10:10:00Z",
 };
 
+const MOCK_ADOPTION_REQUESTS: AdoptionRequest[] = [
+  {
+    id: "adoption-1",
+    status: "DISPUTED",
+    petId: "pet-1",
+    petName: "Buddy",
+    petBreed: "Dog, German Shepherd",
+    petAge: "4 years old",
+    petImageUrl: "https://images.example.com/buddy.jpg",
+    adopterId: "user-1",
+    adopterName: "Angela Christopher",
+    location: "Lekki, Lagos",
+    createdAt: "2026-03-20T08:00:00.000Z",
+    updatedAt: "2026-03-22T09:30:00.000Z",
+  },
+  {
+    id: "adoption-2",
+    status: "DISPUTED",
+    petId: "pet-2",
+    petName: "Milo",
+    petBreed: "Cat, Persian",
+    petAge: "2 years old",
+    petImageUrl: "https://images.example.com/milo.jpg",
+    adopterId: "user-2",
+    adopterName: "Tobi Lawson",
+    location: "Yaba, Lagos",
+    createdAt: "2026-03-18T10:00:00.000Z",
+    updatedAt: "2026-03-21T10:30:00.000Z",
+  },
+  {
+    id: "adoption-3",
+    status: "DISPUTED",
+    petId: "pet-3",
+    petName: "Kiwi",
+    petBreed: "Parrot, African Grey",
+    petAge: "1 year old",
+    petImageUrl: "https://images.example.com/kiwi.jpg",
+    adopterId: "user-3",
+    adopterName: "Samuel Ade",
+    location: "Ikeja, Lagos",
+    createdAt: "2026-03-15T09:00:00.000Z",
+    updatedAt: "2026-03-19T09:45:00.000Z",
+  },
+  {
+    id: "adoption-4",
+    status: "ESCROW_FUNDED",
+    petId: "pet-4",
+    petName: "Luna",
+    petBreed: "Dog, Husky",
+    petAge: "3 years old",
+    petImageUrl: "https://images.example.com/luna.jpg",
+    adopterId: "user-4",
+    adopterName: "Mercy Bello",
+    location: "Abuja",
+    createdAt: "2026-03-16T11:00:00.000Z",
+    updatedAt: "2026-03-20T07:15:00.000Z",
+  },
+  {
+    id: "adoption-5",
+    status: "COMPLETED",
+    petId: "pet-5",
+    petName: "Coco",
+    petBreed: "Dog, Poodle",
+    petAge: "5 years old",
+    petImageUrl: "https://images.example.com/coco.jpg",
+    adopterId: "user-5",
+    adopterName: "David Okafor",
+    location: "Port Harcourt",
+    createdAt: "2026-03-10T09:00:00.000Z",
+    updatedAt: "2026-03-14T16:20:00.000Z",
+  },
+];
+
 export const adoptionHandlers = [
+  http.get("/api/adoption/requests", async ({ request }) => {
+    await delay(100);
+    const statuses = new URL(request.url).searchParams.getAll("status");
+    const filteredRequests = statuses.length
+      ? MOCK_ADOPTION_REQUESTS.filter((requestItem) => statuses.includes(requestItem.status))
+      : MOCK_ADOPTION_REQUESTS;
+
+    return HttpResponse.json(filteredRequests);
+  }),
   http.get("/api/adoption/:id/timeline", async () => {
     await delay(100);
     return HttpResponse.json(MOCK_TIMELINE);

--- a/src/pages/__tests__/interestPage.test.tsx
+++ b/src/pages/__tests__/interestPage.test.tsx
@@ -1,0 +1,120 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../mocks/server";
+import InterestPage from "../interestPage";
+import type { AdoptionRequest } from "../../types/adoption";
+
+const MOCK_REQUESTS: AdoptionRequest[] = [
+  {
+    id: "adoption-1",
+    status: "DISPUTED",
+    petId: "pet-1",
+    petName: "Buddy",
+    petBreed: "Dog, German Shepherd",
+    petAge: "4 years old",
+    petImageUrl: "https://images.example.com/buddy.jpg",
+    adopterId: "user-1",
+    adopterName: "Angela Christopher",
+    location: "Lekki, Lagos",
+    createdAt: "2026-03-20T08:00:00.000Z",
+    updatedAt: "2026-03-22T09:30:00.000Z",
+  },
+  {
+    id: "adoption-2",
+    status: "DISPUTED",
+    petId: "pet-2",
+    petName: "Milo",
+    petBreed: "Cat, Persian",
+    petAge: "2 years old",
+    petImageUrl: "https://images.example.com/milo.jpg",
+    adopterId: "user-2",
+    adopterName: "Tobi Lawson",
+    location: "Yaba, Lagos",
+    createdAt: "2026-03-18T10:00:00.000Z",
+    updatedAt: "2026-03-21T10:30:00.000Z",
+  },
+  {
+    id: "adoption-3",
+    status: "DISPUTED",
+    petId: "pet-3",
+    petName: "Kiwi",
+    petBreed: "Parrot, African Grey",
+    petAge: "1 year old",
+    petImageUrl: "https://images.example.com/kiwi.jpg",
+    adopterId: "user-3",
+    adopterName: "Samuel Ade",
+    location: "Ikeja, Lagos",
+    createdAt: "2026-03-15T09:00:00.000Z",
+    updatedAt: "2026-03-19T09:45:00.000Z",
+  },
+  {
+    id: "adoption-4",
+    status: "ESCROW_FUNDED",
+    petId: "pet-4",
+    petName: "Luna",
+    petBreed: "Dog, Husky",
+    petAge: "3 years old",
+    petImageUrl: "https://images.example.com/luna.jpg",
+    adopterId: "user-4",
+    adopterName: "Mercy Bello",
+    location: "Abuja",
+    createdAt: "2026-03-16T11:00:00.000Z",
+    updatedAt: "2026-03-20T07:15:00.000Z",
+  },
+];
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <InterestPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("InterestPage status filters", () => {
+  it("changes the adoption list query and updates the URL when a filter chip is clicked", async () => {
+    const requestedStatuses: string[][] = [];
+
+    window.history.pushState({}, "", "/interests");
+
+    server.use(
+      http.get("http://localhost:3000/api/adoption/requests", ({ request }) => {
+        const statuses = new URL(request.url).searchParams.getAll("status");
+        requestedStatuses.push(statuses);
+
+        const filteredRequests = statuses.length
+          ? MOCK_REQUESTS.filter((item) => statuses.includes(item.status))
+          : MOCK_REQUESTS;
+
+        return HttpResponse.json(filteredRequests);
+      }),
+    );
+
+    renderPage();
+
+    await screen.findByText("Buddy");
+
+    await waitFor(() => {
+      expect(requestedStatuses.at(-1)).toEqual([]);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Disputed" }));
+
+    await waitFor(() => {
+      expect(requestedStatuses.at(-1)).toEqual(["DISPUTED"]);
+    });
+
+    await screen.findByRole("button", { name: "Disputed (3)" });
+    expect(window.location.search).toContain("status=DISPUTED");
+  });
+});

--- a/src/pages/interestPage.tsx
+++ b/src/pages/interestPage.tsx
@@ -1,276 +1,180 @@
-import { useMemo, useState } from "react";
-import { adoptionService } from "../api/adoptionService";
-import { InterestPetCard, type Pet } from "../components/ui/InterestPetCard";
-import { RatingModal } from "../components/ui/RatingModal";
+import { useMemo } from "react";
+import { AdoptionStatusBadge } from "../components/ui/AdoptionStatusBadge";
+import {
+  StatusFilterChips,
+  formatAdoptionStatusLabel,
+} from "../components/ui/StatusFilterChips";
+import { EmptyState } from "../components/ui/emptyState";
+import { useAdoptionList } from "../hooks/useAdoptionList";
+import { useUrlSync } from "../hooks/useUrlSync";
+import {
+  ADOPTION_STATUS_OPTIONS,
+  type AdoptionRequest,
+  type AdoptionStatus,
+} from "../types/adoption";
 
-import catImg from "../assets/cat.png";
-import dogImg from "../assets/dog.png";
-import parrotImg from "../assets/parrot.png";
+type UrlState = {
+  status: AdoptionStatus[] | AdoptionStatus | string[] | string;
+};
 
-const MOCK_PETS: Pet[] = [
-  {
-    id: "1",
-    name: "Pet For Adoption",
-    breed: "Dog, German Shepard",
-    category: "dog",
-    age: "4yrs old",
-    location: "Mainland, Lagos Nigeria",
-    imageUrl: dogImg,
-    isFavourite: false,
-    isInterested: true,
-    consent: "awaiting",
-    adoption: false,
-  },
-  {
-    id: "2",
-    name: "Pet For Adoption",
-    breed: "Parrot",
-    category: "bird",
-    age: "4yrs old",
-    location: "Mainland, Lagos Nigeria",
-    imageUrl: parrotImg,
-    isFavourite: false,
-    isInterested: true,
-    consent: "granted",
-    adoption: false,
-  },
-  {
-    id: "3",
-    name: "Buddy",
-    breed: "Cat, Persian",
-    category: "cat",
-    age: "4yrs old",
-    location: "Mainland, Lagos Nigeria",
-    imageUrl: catImg,
-    isFavourite: false,
-    isInterested: true,
-    consent: "granted",
-    adoption: true,
-    completed: false,
-  },
-];
+function normalizeStatuses(value: UrlState["status"]): AdoptionStatus[] {
+  if (Array.isArray(value)) {
+    return value.filter(Boolean) as AdoptionStatus[];
+  }
 
+  if (typeof value === "string" && value.length > 0) {
+    return [value as AdoptionStatus];
+  }
+
+  return [];
+}
+
+function buildNextStatuses(
+  currentStatuses: AdoptionStatus[],
+  status: AdoptionStatus,
+): AdoptionStatus[] {
+  return currentStatuses.includes(status)
+    ? currentStatuses.filter((value) => value !== status)
+    : [...currentStatuses, status];
+}
+
+function getEmptyStateTitle(selectedStatuses: AdoptionStatus[]) {
+  if (selectedStatuses.length === 1) {
+    return "No " + formatAdoptionStatusLabel(selectedStatuses[0]).toLowerCase() + " adoptions";
+  }
+
+  return "No matching adoptions";
+}
+
+function getEmptyStateDescription(selectedStatuses: AdoptionStatus[]) {
+  if (selectedStatuses.length > 0) {
+    return "Try a different status filter to see other adoption requests.";
+  }
+
+  return "Adoption requests will appear here once they are created.";
+}
+
+function formatDate(dateString: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(dateString));
+}
+
+function AdoptionRequestRow({ request }: { request: AdoptionRequest }) {
+  return (
+    <article className="grid gap-4 rounded-2xl border border-[#EAEAEA] bg-white p-5 shadow-sm md:grid-cols-[1.6fr_1fr_auto] md:items-center">
+      <div className="flex items-center gap-4 min-w-0">
+        <img
+          src={request.petImageUrl}
+          alt={request.petName}
+          className="h-16 w-16 rounded-xl object-cover bg-gray-100"
+        />
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold text-[#0D162B]">
+            {request.petName}
+          </h2>
+          <p className="truncate text-sm text-[#686677]">
+            {request.petBreed}, {request.petAge}
+          </p>
+          <p className="mt-1 truncate text-sm text-[#4D5761]">
+            Adopter: {request.adopterName}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-1 text-sm text-[#4D5761]">
+        <p>{request.location}</p>
+        <p>Updated {formatDate(request.updatedAt)}</p>
+      </div>
+
+      <div className="justify-self-start md:justify-self-end">
+        <AdoptionStatusBadge status={request.status} />
+      </div>
+    </article>
+  );
+}
 
 export default function InterestPage() {
-  const [pets, setPets] = useState<Pet[]>(MOCK_PETS);
-  const [locationFilter, setLocationFilter] = useState("");
-  const [categoryFilter, setCategoryFilter] = useState("all");
-  const [ratingModalOpen, setRatingModalOpen] = useState(false);
-  const [selectedPet, setSelectedPet] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
+  const [urlState, setUrlState] = useUrlSync<UrlState>({ status: [] });
+  const selectedStatuses = normalizeStatuses(urlState.status);
+  const { data, isLoading, isError, error } = useAdoptionList({
+    status: selectedStatuses,
+  });
 
-  const filteredPets = useMemo(() => {
-    return pets.filter((pet) => {
-      if (!pet.isInterested) return false;
+  const requests = data ?? [];
 
-      const matchesCategory =
-        categoryFilter === "all" || pet.category === categoryFilter;
+  const counts = useMemo(() => {
+    return selectedStatuses.reduce((result, status) => {
+      result[status] = requests.filter((request) => request.status === status).length;
+      return result;
+    }, {} as Partial<Record<AdoptionStatus, number>>);
+  }, [requests, selectedStatuses]);
 
-      const matchesLocation =
-        locationFilter === "" ||
-        pet.location.toLowerCase().includes(locationFilter.toLowerCase());
-
-      return matchesCategory && matchesLocation;
-    });
-  }, [pets, locationFilter, categoryFilter]);
-
-  const handleRemove = (id: string) => {
-    setPets((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, isInterested: false } : p)),
-    );
-  };
-
-  const handleViewDetails = () => {
-    // placeholder for navigation to listing detail page
-  };
-
-  const handleStartAdoption = (id: string) => {
-    setPets((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, adoption: true } : p)),
-    );
-  };
-
-  const handleConfirmCompletion = (id: string) => {
-    setPets((prev) =>
-      prev.map((p) => (p.id === id ? { ...p, completed: true } : p)),
-    );
-  };
-
-  const handleRateAdoption = (id: string, petName: string) => {
-    setSelectedPet({ id, name: petName });
-    setRatingModalOpen(true);
-  };
-
-  const handleRatingSubmit = async (rating: number, feedback: string) => {
-    if (!selectedPet) return;
-
-    try {
-      await adoptionService.submitRating({
-        rating,
-        feedback,
-        adoptionId: selectedPet.id,
-        petId: selectedPet.id,
-      });
-      setRatingModalOpen(false);
-      setSelectedPet(null);
-    } catch (error) {
-      console.error("Failed to submit rating:", error);
-    }
-  };
-
-  const handleRatingModalClose = () => {
-    setRatingModalOpen(false);
-    setSelectedPet(null);
-  };
-
-  const handleResetFilters = () => {
-    setLocationFilter("");
-    setCategoryFilter("all");
+  const handleToggleStatus = (status: AdoptionStatus) => {
+    setUrlState({ status: buildNextStatuses(selectedStatuses, status) });
   };
 
   return (
-    <div className="min-h-screen bg-[white] pb-24" style={{ fontFamily: "Poppins, sans-serif" }}>
-      <div className="bg-white h-6" />
-
-      <div className="max-full px-4 lg:px-20">
-        <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 gap-4">
-            <h1 className="text-[20px] font-semibold text-[#001323]" style={{ lineHeight: "36px" }}>
-            Interest ({filteredPets.length})
-            </h1>
-
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="relative w-full sm:w-[220px]">
-              {/* <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
-                <svg
-                  className="w-4.5 h-4.5 text-gray-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </div>
-              <input
-                type="text"
-                placeholder="filter by Location"
-                value={locationFilter}
-                onChange={(e) => setLocationFilter(e.target.value)}
-                className="w-full pl-11 pr-4 py-2.5 rounded-xl border border-gray-200 bg-white text-[14px] outline-none focus:border-[#0D162B] transition-colors"
-              /> */}
+    <div className="min-h-screen bg-[#F9FAFB] px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <div className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-[#001323]">
+                Adoption Requests ({requests.length})
+              </h1>
+              <p className="text-sm text-[#4D5761]">
+                Filter adoption requests by status and keep the URL in sync.
+              </p>
             </div>
-
-            <div className="w-[160px] relative">
-              {/* <FormSelect
-                id="category-filter"
-                label=""
-                options={CATEGORY_OPTIONS}
-                value={categoryFilter}
-                onChange={(e) => setCategoryFilter(e.target.value)}
-                className="!py-2.5"
-              /> */}
-            </div>
-
-            {/* <button
-              onClick={handleResetFilters}
-              className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-gray-100 text-gray-600 font-medium text-[14px] hover:bg-gray-200 transition-colors"
-            >
-              <svg
-                className="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                />
-              </svg>
-              Reset
-            </button> */}
           </div>
+
+          <StatusFilterChips
+            options={ADOPTION_STATUS_OPTIONS}
+            selectedStatuses={selectedStatuses}
+            counts={counts}
+            onToggle={handleToggleStatus}
+          />
         </div>
 
-        {filteredPets.length > 0 ? (
-          <div>
-            <div className="hidden lg:grid grid-cols-[2fr_1.2fr_1.2fr_1.5fr] gap-6 pb-3 text-[14px] font-semibold text-[#001323] uppercase tracking-wider">
-              <span>Details</span>
-              <span>Location</span>
-              <span>Status</span>
-              <span></span>
-            </div>
+        {isLoading ? (
+          <div className="rounded-2xl border border-[#EAEAEA] bg-white px-6 py-12 text-center text-sm text-[#4D5761]">
+            Loading adoption requests...
+          </div>
+        ) : null}
 
-            <div className="flex flex-col gap-3">
-              {filteredPets.map((pet) => (
-                <InterestPetCard
-                  key={pet.id}
-                  pet={pet}
-                  onRemove={handleRemove}
-                  onViewDetails={handleViewDetails}
-                  onStartAdoption={handleStartAdoption}
-                  onConfirmCompletion={handleConfirmCompletion}
-                  onRateAdoption={handleRateAdoption}
-                />
-              ))}
-            </div>
+        {!isLoading && isError ? (
+          <EmptyState
+            title="Unable to load adoption requests"
+            description={error?.message ?? "Please try again shortly."}
+          />
+        ) : null}
+
+        {!isLoading && !isError && requests.length === 0 ? (
+          <EmptyState
+            title={getEmptyStateTitle(selectedStatuses)}
+            description={getEmptyStateDescription(selectedStatuses)}
+            action={
+              selectedStatuses.length > 0
+                ? {
+                    label: "Clear filters",
+                    onClick: () => setUrlState({ status: [] }),
+                  }
+                : undefined
+            }
+          />
+        ) : null}
+
+        {!isLoading && !isError && requests.length > 0 ? (
+          <div className="space-y-4">
+            {requests.map((request) => (
+              <AdoptionRequestRow key={request.id} request={request} />
+            ))}
           </div>
-        ) : (
-          <div className="flex flex-col items-center justify-center py-32 text-center bg-white rounded-2xl border border-gray-100">
-            <div className="w-20 h-20 bg-gray-50 rounded-full flex items-center justify-center mb-4">
-              <svg
-                className="w-10 h-10 text-gray-300"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={1.5}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-            </div>
-            <h3 className="text-xl font-bold text-gray-900 mb-2">
-              No interests found
-            </h3>
-            <p className="text-gray-500 max-w-[300px]">
-              {pets.filter((p) => p.isInterested).length > 0
-                ? "No pets match your current filter criteria. Try resetting the filters."
-                : "You haven't expressed interest in adopting any pets yet."}
-            </p>
-            {pets.filter((p) => p.isInterested).length > 0 && (
-              <button
-                onClick={handleResetFilters}
-                className="mt-6 text-[#E84D2A] font-medium hover:underline"
-              >
-                Clear Filters
-              </button>
-            )}
-          </div>
-        )}
+        ) : null}
       </div>
-
-      {/* Rating Modal */}
-      <RatingModal
-        isOpen={ratingModalOpen}
-        onClose={handleRatingModalClose}
-        onSubmit={handleRatingSubmit}
-        petName={selectedPet?.name}
-      />
     </div>
   );
 }

--- a/src/types/adoption.ts
+++ b/src/types/adoption.ts
@@ -8,16 +8,27 @@ export type AdoptionStatus =
   | "COMPLETED"
   | "CANCELLED";
 
+export const ADOPTION_STATUS_OPTIONS: AdoptionStatus[] = [
+  "ESCROW_CREATED",
+  "ESCROW_FUNDED",
+  "SETTLEMENT_TRIGGERED",
+  "DISPUTED",
+  "FUNDS_RELEASED",
+  "CUSTODY_ACTIVE",
+  "COMPLETED",
+  "CANCELLED",
+];
+
 export interface AdoptionTimelineEntry {
   id: string;
   adoptionId: string;
   timestamp: string;
   sdkEvent: string;
   message: string;
-  actor?: string;
+  actor: string;
   actorRole?: string;
-  fromStatus?: AdoptionStatus;
-  toStatus?: AdoptionStatus;
+  fromStatus: AdoptionStatus | null;
+  toStatus: AdoptionStatus;
   sdkTxHash?: string;
   isAdminOverride?: boolean;
   reason?: string;
@@ -28,6 +39,21 @@ export interface AdoptionDetails {
   status: AdoptionStatus;
   petId: string;
   adopterId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AdoptionRequest {
+  id: string;
+  status: AdoptionStatus;
+  petId: string;
+  petName: string;
+  petBreed: string;
+  petAge: string;
+  petImageUrl: string;
+  adopterId: string;
+  adopterName: string;
+  location: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- add status filter chips to the adoption requests list page
- wire selected statuses into `useAdoptionList({ status })`
- send selected statuses to `GET /adoption/requests`
- show active chip counts like `Disputed (3)`
- add filter-specific empty state messaging
- add unit coverage for filter query and URL sync

## Testing
- `npm test -- --run src/pages/__tests__/interestPage.test.tsx`
- `npm run build`
