### PR TITLE
feat: implement useEscrowApiLayer - all escrow hooks with optimistic

### DIFF
--- a/src/hooks/__tests__/useMutateCompleteAdoption.test.tsx
+++ b/src/hooks/__tests__/useMutateCompleteAdoption.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
 import { useMutateCompleteAdoption } from "../useMutateCompleteAdoption";
 import { server } from "../../mocks/server";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import type { AdoptionDetails } from "../../types/adoption";
 
@@ -34,114 +34,183 @@ const MOCK_ADOPTION: AdoptionDetails = {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("useMutateCompleteAdoption", () => {
-  it("optimistic update: cache is set to SETTLEMENT_PENDING status before server responds", async () => {
-    // Use a slow handler so the mutation is still in-flight when we inspect
-    let resolveRequest!: () => void;
-    const requestInflight = new Promise<void>((res) => {
-      resolveRequest = res;
-    });
+  describe("loading state", () => {
+    it("isPending is true while mutation is in-flight", async () => {
+      let resolveRequest!: () => void;
+      const requestInflight = new Promise<void>((res) => {
+        resolveRequest = res;
+      });
 
-    server.use(
-      http.post(
-        "http://localhost:3000/api/adoption/:id/complete",
-        async () => {
+      server.use(
+        http.post("http://localhost:3000/api/adoption/:id/complete", async () => {
           await requestInflight;
-          return HttpResponse.json<AdoptionDetails>({
-            ...MOCK_ADOPTION,
-            status: "SETTLEMENT_TRIGGERED",
-          });
-        },
-      ),
-    );
-
-    const { queryClient, wrapper } = createWrapper();
-    // Seed the cache with the current adoption data
-    queryClient.setQueryData<AdoptionDetails>(["adoption", "adoption-1"], MOCK_ADOPTION);
-
-    const { result } = renderHook(
-      () => useMutateCompleteAdoption("adoption-1"),
-      { wrapper },
-    );
-
-    // Apply an optimistic update to the cache before mutation resolves
-    act(() => {
-      queryClient.setQueryData<AdoptionDetails>(["adoption", "adoption-1"], (old) =>
-        old ? { ...old, status: "SETTLEMENT_TRIGGERED" } : old,
+          return new HttpResponse(null, { status: 204 });
+        }),
       );
-      result.current.mutateCompleteAdoption();
+
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("adoption-1"),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
+
+      // While in-flight, isPending should be true
+      expect(result.current.isPending).toBe(true);
+      expect(result.current.isError).toBe(false);
+
+      resolveRequest();
+      await waitFor(() => expect(result.current.isPending).toBe(false));
     });
-
-    // While in-flight: cache should reflect optimistic status
-    const optimisticData = queryClient.getQueryData<AdoptionDetails>([
-      "adoption",
-      "adoption-1",
-    ]);
-    expect(optimisticData?.status).toBe("SETTLEMENT_TRIGGERED");
-
-    // Let the request complete
-    resolveRequest();
-    await waitFor(() => expect(result.current.isPending).toBe(false));
-    expect(result.current.isError).toBe(false);
   });
 
-  it("rollback on error: cache is restored to previous snapshot when mutation fails", async () => {
-    server.use(
-      http.post(
-        "http://localhost:3000/api/adoption/:id/complete",
-        ({ params }) => {
-          if (params.id === "fail") {
-            return HttpResponse.json({ error: "Server error" }, { status: 500 });
-          }
-          return HttpResponse.json<AdoptionDetails>({
-            ...MOCK_ADOPTION,
-            status: "SETTLEMENT_TRIGGERED",
-          });
-        },
-      ),
-    );
+  describe("success state", () => {
+    it("isError is false and isPending becomes false on success", async () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("adoption-1"),
+        { wrapper },
+      );
 
-    const { queryClient, wrapper } = createWrapper();
-    // Seed cache with the original adoption state
-    queryClient.setQueryData<AdoptionDetails>(["adoption", "fail"], MOCK_ADOPTION);
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
 
-    const { result } = renderHook(
-      () => useMutateCompleteAdoption("fail"),
-      { wrapper },
-    );
+      await waitFor(() => expect(result.current.isPending).toBe(false));
 
-    act(() => {
-      result.current.mutateCompleteAdoption();
+      expect(result.current.isError).toBe(false);
+      expect(result.current.error).toBeNull();
     });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
+    it("invalidates the adoption query on success", async () => {
+      const { queryClient, wrapper } = createWrapper();
+      queryClient.setQueryData<AdoptionDetails>(["adoption", "adoption-1"], MOCK_ADOPTION);
 
-    // After failure, isError should be true and isPending false
-    expect(result.current.isPending).toBe(false);
-    expect(result.current.isError).toBe(true);
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("adoption-1"),
+        { wrapper },
+      );
+
+      await act(async () => {
+        result.current.mutateCompleteAdoption();
+      });
+
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+
+      expect(result.current.isError).toBe(false);
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["adoption", "adoption-1"] }),
+      );
+    });
   });
 
-  it("on success: invalidates the adoption query and clears error state", async () => {
-    const { queryClient, wrapper } = createWrapper();
-    queryClient.setQueryData<AdoptionDetails>(["adoption", "adoption-1"], MOCK_ADOPTION);
+  describe("error state", () => {
+    it("isError is true and isPending becomes false when server returns 500", async () => {
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("fail"),
+        { wrapper },
+      );
 
-    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
 
-    const { result } = renderHook(
-      () => useMutateCompleteAdoption("adoption-1"),
-      { wrapper },
-    );
+      await waitFor(() => expect(result.current.isError).toBe(true));
 
-    await act(async () => {
-      result.current.mutateCompleteAdoption();
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.error).not.toBeNull();
+    });
+  });
+
+  describe("optimistic update", () => {
+    it("applies optimistic update (SETTLEMENT_TRIGGERED) before server responds", async () => {
+      let resolveRequest!: () => void;
+      const requestInflight = new Promise<void>((res) => {
+        resolveRequest = res;
+      });
+
+      server.use(
+        http.post("http://localhost:3000/api/adoption/:id/complete", async () => {
+          await requestInflight;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      const { queryClient, wrapper } = createWrapper();
+      queryClient.setQueryData<AdoptionDetails>(["adoption", "adoption-1"], MOCK_ADOPTION);
+
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("adoption-1"),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
+
+      // While in-flight: cache should reflect optimistic SETTLEMENT_TRIGGERED status
+      const optimisticData = queryClient.getQueryData<AdoptionDetails>([
+        "adoption",
+        "adoption-1",
+      ]);
+      expect(optimisticData?.status).toBe("SETTLEMENT_TRIGGERED");
+
+      resolveRequest();
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+    });
+  });
+
+  describe("rollback on error", () => {
+    it("restores previous cache state when mutation fails", async () => {
+      const { queryClient, wrapper } = createWrapper();
+      // Seed cache with the original adoption state
+      queryClient.setQueryData<AdoptionDetails>(["adoption", "fail"], MOCK_ADOPTION);
+
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("fail"),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      // After failure, cache should be restored to original state
+      const restoredData = queryClient.getQueryData<AdoptionDetails>([
+        "adoption",
+        "fail",
+      ]);
+      expect(restoredData?.status).toBe("ESCROW_FUNDED");
+      expect(restoredData?.id).toBe("fail");
     });
 
-    await waitFor(() => expect(result.current.isPending).toBe(false));
+    it("clears optimistic update and shows error state on failure", async () => {
+      const { queryClient, wrapper } = createWrapper();
+      queryClient.setQueryData<AdoptionDetails>(["adoption", "fail"], MOCK_ADOPTION);
 
-    expect(result.current.isError).toBe(false);
-    // useApiMutation's onSuccess calls invalidateQueries for ["adoption", adoptionId]
-    // and useMutateCompleteAdoption also manually calls it in its own onSuccess:
-    expect(invalidateSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ["adoption", "adoption-1"] }),
-    );
+      const { result } = renderHook(
+        () => useMutateCompleteAdoption("fail"),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.mutateCompleteAdoption();
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      // Error state should be set correctly
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).not.toBeNull();
+    });
   });
 });

--- a/src/hooks/useMutateCompleteAdoption.ts
+++ b/src/hooks/useMutateCompleteAdoption.ts
@@ -1,7 +1,18 @@
 import { useApiMutation } from "./useApiMutation";
 import { useQueryClient } from "@tanstack/react-query";
 import { adoptionService } from "../api/adoptionService";
+import type { AdoptionDetails } from "../types/adoption";
 
+/**
+ * useMutateCompleteAdoption
+ *
+ * Triggers settlement for an escrow-funded adoption.
+ *
+ * Implements optimistic update pattern:
+ * 1. onMutate → snapshots cache, applies SETTLEMENT_TRIGGERED status
+ * 2. onError  → rolls back to previous snapshot
+ * 3. onSuccess → invalidates adoption query to refetch fresh state
+ */
 export function useMutateCompleteAdoption(adoptionId: string) {
     const queryClient = useQueryClient();
 
@@ -9,6 +20,33 @@ export function useMutateCompleteAdoption(adoptionId: string) {
         (id: string) => adoptionService.completeAdoption(id),
         {
             invalidates: [["adoption", adoptionId]],
+            onOptimisticUpdate: () => {
+                // Snapshot current cache for potential rollback
+                const previousData = queryClient.getQueryData<AdoptionDetails>([
+                    "adoption",
+                    adoptionId,
+                ]);
+
+                // Apply optimistic update: SETTLEMENT_TRIGGERED status
+                queryClient.setQueryData<AdoptionDetails>(
+                    ["adoption", adoptionId],
+                    (old) =>
+                        old
+                            ? { ...old, status: "SETTLEMENT_TRIGGERED" as const }
+                            : old,
+                );
+
+                return previousData;
+            },
+            onRollback: (snapshot) => {
+                // Restore previous cache state on error
+                if (snapshot !== undefined) {
+                    queryClient.setQueryData<AdoptionDetails>(
+                        ["adoption", adoptionId],
+                        snapshot as AdoptionDetails | undefined,
+                    );
+                }
+            },
             onSuccess: () => {
                 queryClient.invalidateQueries({ queryKey: ["adoption", adoptionId] });
             },

--- a/src/mocks/handlers/adoption.ts
+++ b/src/mocks/handlers/adoption.ts
@@ -56,4 +56,16 @@ export const adoptionHandlers = [
 
     return HttpResponse.json({ error: "Adoption not found" }, { status: 404 });
   }),
+
+  // POST /api/adoption/:id/complete — trigger settlement completion
+  http.post("/api/adoption/:id/complete", async ({ params }) => {
+    await delay(100);
+    const { id } = params;
+
+    if (id === "fail") {
+      return HttpResponse.json({ error: "Failed to complete adoption" }, { status: 500 });
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/src/mocks/handlers/escrow.ts
+++ b/src/mocks/handlers/escrow.ts
@@ -128,4 +128,32 @@ export const escrowHandlers = [
 
 		return HttpResponse.json(summary);
 	}),
+
+	// POST /api/escrow/:id/retry-settlement — retry a failed settlement
+	http.post("/api/escrow/:id/retry-settlement", async ({ request, params }) => {
+		await delay(getDelay(request));
+		const id = params.id as string;
+
+		if (id === "fail") {
+			return HttpResponse.json({ error: "Retry settlement failed" }, { status: 500 });
+		}
+
+		return new HttpResponse(null, { status: 204 });
+	}),
+
+	// GET /api/escrow/:id/status — get escrow status (for polling)
+	http.get("/api/escrow/:id/status", async ({ request, params }) => {
+		await delay(getDelay(request));
+		const id = params.id as string;
+
+		if (id === "not-found") {
+			return new HttpResponse(null, { status: 404 });
+		}
+
+		return HttpResponse.json<Escrow>({
+			...BASE_ESCROW,
+			id,
+			status: "FUNDED",
+		});
+	}),
 ];


### PR DESCRIPTION
Closes #129 

## Issue
**Issue #129**: [Frontend · Escrow settlement UI] Create useEscrowApiLayer — all escrow hooks

## Summary
Implemented a complete set of React Query hooks for all escrow API endpoints with MSW mock handlers and comprehensive unit tests.

## Changes

### Hooks Implemented/Enhanced

1. **useEscrowStatus(escrowId)**
   - Status: Pre-existing (working implementation)
   - Polling hook that automatically stops on terminal status (COMPLETED/CANCELLED)

2. **useSettlementSummary(escrowId)**
   - Status: Pre-existing (working implementation)
   - GET /escrow/:id/settlement-summary

3. **useMutateCompleteAdoption(adoptionId)**
   - Status: Enhanced with optimistic update pattern
   - POST /adoption/:id/complete
   - Optimistic update: Sets status to SETTLEMENT_TRIGGERED before server responds
   - Rollback: Restores previous cache state on mutation failure

4. **useRetrySettlement(escrowId)**
   - Status: Pre-existing (working implementation)
   - POST /escrow/:id/retry-settlement

### MSW Mock Handlers Added

1. **escrow.ts**
   - POST /api/escrow/:id/retry-settlement (returns 204 on success, 500 for "fail" id)
   - GET /api/escrow/:id/status (returns escrow status for polling)

2. **adoption.ts**
   - POST /api/adoption/:id/complete (returns 204 on success, 500 for "fail" id)

### Tests Added/Enhanced

**useMutateCompleteAdoption.test.tsx**
- Loading state: isPending true while mutation is in-flight
- Success state: isError false, invalidation called on success
- Error state: isError true with error object set
- Optimistic update: Cache shows SETTLEMENT_TRIGGERED before server responds
- Rollback on error: Cache restored to original state on failure

## Files Modified

| File | Change |
|------|--------|
| src/hooks/useMutateCompleteAdoption.ts | Enhanced with optimistic update/rollback |
| src/mocks/handlers/escrow.ts | Added retry-settlement and status handlers |
| src/mocks/handlers/adoption.ts | Added complete adoption handler |
| src/hooks/__tests__/useMutateCompleteAdoption.test.tsx | Comprehensive test coverage |

## Technical Details

### Optimistic Update Pattern
The useMutateCompleteAdoption hook now implements the optimistic update pattern:
1. `onMutate`: Snapshot cache, apply optimistic status
2. `onError`: Restore snapshot via rollback
3. `onSuccess`: Invalidate queries to refetch fresh state

### Terminal Status Definitions
Polling stops when adoption reaches:
- COMPLETED
- CANCELLED

## Testing
Run tests locally:
```bash
npm test
```

## Epic
Part of Epic: Escrow settlement UI (Phase 2)

## Labels
api, state, phase-2, frontend
