### PR TITLE
feat(ui): DisputeBanner component — closes #192

### DIFF
--- a/src/components/escrow/DisputeBanner.tsx
+++ b/src/components/escrow/DisputeBanner.tsx
@@ -1,0 +1,95 @@
+
+import { AlertTriangle } from "lucide-react";
+import { Link } from "react-router-dom";
+import { StellarTxLink } from "./StellarTxLink";
+
+export interface DisputeBannerProps {
+  disputeId: string;
+  raisedAt: string;
+  escrowAccountId: string;
+}
+
+function formatRaisedAt(iso: string): string {
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function DisputeBanner({
+  disputeId,
+  raisedAt,
+  escrowAccountId,
+}: DisputeBannerProps) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="dispute-banner"
+      className="rounded-3xl border border-red-200 bg-red-50 p-5 text-red-950"
+    >
+      <div className="flex items-start gap-3">
+        <AlertTriangle
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 text-red-500"
+          size={18}
+        />
+        <div className="flex-1">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-red-700">
+            Dispute in Progress
+          </p>
+          <p className="mt-2 text-lg font-semibold">
+            A dispute has been raised. Escrow settlement is paused.
+          </p>
+          <dl className="mt-3 grid gap-2 sm:grid-cols-2">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-red-600">
+                Dispute ID
+              </dt>
+              <dd
+                className="mt-1 text-sm font-medium text-red-900"
+                data-testid="dispute-id"
+              >
+                {disputeId}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-red-600">
+                Raised
+              </dt>
+              <dd
+                className="mt-1 text-sm font-medium text-red-900"
+                data-testid="dispute-raised-at"
+              >
+                {formatRaisedAt(raisedAt)}
+              </dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-red-600">
+                Escrow Account
+              </dt>
+              <dd className="mt-1">
+                <StellarTxLink txHash={escrowAccountId} />
+              </dd>
+            </div>
+          </dl>
+          <p className="mt-4 text-sm text-red-800">
+            Review the dispute and submitted evidence.{" "}
+            <Link
+              to={`/disputes/${disputeId}`}
+              data-testid="dispute-detail-link"
+              className="font-semibold underline underline-offset-2 hover:text-red-950"
+            >
+              View dispute details
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/escrow/EscrowStatusCard.tsx
+++ b/src/components/escrow/EscrowStatusCard.tsx
@@ -3,6 +3,7 @@ import { EscrowStatusBadge } from "./EscrowStatusBadge";
 import { StellarTxLink } from "./StellarTxLink";
 import { usePolling } from "../../lib/hooks/usePolling";
 import { formatAmount, type EscrowStatusData } from "./types";
+import { DisputeBanner } from './DisputeBanner';
 
 interface EscrowStatusCardProps {
   escrowId: string;
@@ -53,6 +54,7 @@ export function EscrowStatusCard({
     );
   }
 
+
   return (
     <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -71,7 +73,15 @@ export function EscrowStatusCard({
       </div>
 
       <div className="mt-6">
-        <EscrowProgressStepper status={data.status} />
+        {data.status === 'DISPUTED' && data.disputeId ? (
+          <DisputeBanner
+            disputeId={data.disputeId}
+            raisedAt={data.disputeRaisedAt ?? data.fundedAt ?? new Date().toISOString()}
+            escrowAccountId={data.escrowId}
+          />
+        ) : (
+          <EscrowProgressStepper status={data.status} />
+        )}
       </div>
 
       <dl className="mt-6 grid gap-4 md:grid-cols-2">

--- a/src/components/escrow/__tests__/DisputeBanner.test.tsx
+++ b/src/components/escrow/__tests__/DisputeBanner.test.tsx
@@ -1,0 +1,77 @@
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import { DisputeBanner } from "../DisputeBanner";
+
+vi.mock("../StellarTxLink", () => ({
+  StellarTxLink: ({ txHash }: { txHash: string }) => (
+    <span data-testid="stellar-tx-link">{txHash}</span>
+  ),
+}));
+
+const DEFAULT_PROPS = {
+  disputeId: "dispute-001",
+  raisedAt: "2026-03-23T10:45:00.000Z",
+  escrowAccountId: "GABC1234ESCROWXYZ",
+};
+
+function renderBanner(props = DEFAULT_PROPS) {
+  return render(
+    <MemoryRouter>
+      <DisputeBanner {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("DisputeBanner", () => {
+  it("renders the main dispute message", () => {
+    renderBanner();
+    expect(
+      screen.getByText("A dispute has been raised. Escrow settlement is paused."),
+    ).toBeInTheDocument();
+  });
+
+  it("has role=alert for screen reader announcement", () => {
+    renderBanner();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("displays the dispute ID", () => {
+    renderBanner();
+    expect(screen.getByTestId("dispute-id")).toHaveTextContent("dispute-001");
+  });
+
+  it("displays a formatted raised date containing the year", () => {
+    renderBanner();
+    expect(screen.getByTestId("dispute-raised-at").textContent).toContain("2026");
+  });
+
+  it("renders StellarTxLink with the escrowAccountId", () => {
+    renderBanner();
+    expect(screen.getByTestId("stellar-tx-link")).toHaveTextContent("GABC1234ESCROWXYZ");
+  });
+
+  it("renders a link to the dispute detail page", () => {
+    renderBanner();
+    const link = screen.getByTestId("dispute-detail-link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/disputes/dispute-001");
+  });
+
+  it("uses the correct dispute route for a different disputeId", () => {
+    render(
+      <MemoryRouter>
+        <DisputeBanner
+          disputeId="dispute-999"
+          raisedAt="2026-01-01T00:00:00.000Z"
+          escrowAccountId="GXYZ"
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("dispute-detail-link")).toHaveAttribute(
+      "href",
+      "/disputes/dispute-999",
+    );
+  });
+});

--- a/src/components/escrow/types.ts
+++ b/src/components/escrow/types.ts
@@ -1,3 +1,4 @@
+
 export const ESCROW_STATUSES = [
   "AWAITING_FUNDS",
   "FUNDED",
@@ -20,6 +21,8 @@ export interface EscrowStatusData {
   settledAt?: string;
   failureReason?: string;
   txHash?: string;
+  disputeId?: string;
+  disputeRaisedAt?: string;
 }
 
 export interface SettlementSummary {


### PR DESCRIPTION
## Summary
Implements the `DisputeBanner` component for the Dispute System UI epic,
closing issue #192.

## What's New

- **`DisputeBanner.tsx`** — Red alert banner shown when an adoption has
  an active dispute. Replaces `EscrowProgressStepper` in `EscrowStatusCard`
  when `status === "DISPUTED"`.
- **`types.ts`** — Added `disputeId?: string` and `disputeRaisedAt?: string`
  to `EscrowStatusData`
- **`EscrowStatusCard.tsx`** — Conditionally renders `DisputeBanner` instead
  of `EscrowProgressStepper` when disputed

## Tasks Completed
- [x] Accepts `disputeId`, `raisedAt`, `escrowAccountId` props
- [x] Shows "A dispute has been raised. Escrow settlement is paused."
- [x] Shows dispute ID and raised date
- [x] `StellarTxLink` for `escrowAccountId`
- [x] Links to `/disputes/:id`
- [x] Replaces `EscrowProgressStepper` with "Dispute in Progress" message
- [x] `role="alert"` for accessibility
- [x] Unit tests: renders when dispute present, navigates to dispute detail

## Test Results
```
✓ DisputeBanner (7 tests)
  ✓ renders the main dispute message
  ✓ has role=alert for screen reader announcement
  ✓ displays the dispute ID
  ✓ displays a formatted raised date containing the year
  ✓ renders StellarTxLink with the escrowAccountId
  ✓ renders a link to the dispute detail page
  ✓ uses the correct dispute route for a different disputeId

Test Files  1 passed | Tests  7 passed
```

## Checklist
- [x] `npm test` — 7/7 passing
- [x] `tsc --noEmit` — 0 errors
- [x] Follows existing banner patterns (`CustodyExpiringBanner`, `EscrowFundedBanner`)
- [x] Accessible — `role="alert"`, `aria-live="assertive"`