### PR TITLE
feat(notifications): implement NotificationItem component (#227)

### DIFF
--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -1,0 +1,179 @@
+import { Link2, AlertTriangle, CheckCircle, Clock, Bell } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { notificationRouter } from '../../lib/notificationRouter';
+import type { Notification, NotificationType } from '../../types/notifications';
+
+
+export interface NotificationItemProps {
+  notification: Notification;
+  isRead: boolean;
+  onRead: (id: string | number) => void;
+}
+
+
+interface TimeDisplay {
+  relative: string;
+  absolute: string | null;
+}
+
+function getTimeDisplay(timeStr: string): TimeDisplay {
+  const date = new Date(timeStr);
+
+  if (!isNaN(date.getTime())) {
+    const diffMs = Date.now() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60_000);
+    const diffHours = Math.floor(diffMs / 3_600_000);
+    const diffDays = Math.floor(diffMs / 86_400_000);
+
+    let relative: string;
+    if (diffMins < 1) {
+      relative = 'just now';
+    } else if (diffMins < 60) {
+      relative = `${diffMins} minute${diffMins !== 1 ? 's' : ''} ago`;
+    } else if (diffHours < 24) {
+      relative = `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
+    } else {
+      relative = `${diffDays} day${diffDays !== 1 ? 's' : ''} ago`;
+    }
+
+    return { relative, absolute: date.toLocaleString() };
+  }
+
+  return { relative: timeStr, absolute: null };
+}
+
+
+interface IconConfig {
+  icon: React.ReactNode;
+  wrapperBg: string;
+}
+
+function getIconConfig(type: NotificationType): IconConfig {
+  const t = type.toUpperCase();
+
+  if (t.includes('ESCROW') || t.includes('SETTLEMENT')) {
+    return {
+      icon: <Link2 className="w-4 h-4 text-teal-600" aria-hidden="true" />,
+      wrapperBg: 'bg-teal-100',
+    };
+  }
+  if (t.includes('DISPUTE')) {
+    return {
+      icon: <AlertTriangle className="w-4 h-4 text-red-600" aria-hidden="true" />,
+      wrapperBg: 'bg-red-100',
+    };
+  }
+  if (t.includes('APPROVAL')) {
+    return {
+      icon: <CheckCircle className="w-4 h-4 text-green-600" aria-hidden="true" />,
+      wrapperBg: 'bg-green-100',
+    };
+  }
+  if (t.includes('DOCUMENT') || t.includes('CUSTODY')) {
+    return {
+      icon: <Clock className="w-4 h-4 text-amber-600" aria-hidden="true" />,
+      wrapperBg: 'bg-amber-100',
+    };
+  }
+
+  return {
+    icon: <Bell className="w-4 h-4 text-gray-500" aria-hidden="true" />,
+    wrapperBg: 'bg-gray-100',
+  };
+}
+
+export function NotificationItem({
+  notification,
+  isRead,
+  onRead,
+}: NotificationItemProps) {
+  const navigate = useNavigate();
+  const { relative, absolute } = getTimeDisplay(notification.time);
+  const { icon, wrapperBg } = getIconConfig(notification.type);
+
+  function handleActivate() {
+    onRead(notification.id);
+    navigate(notificationRouter(notification));
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${isRead ? 'Read' : 'Unread'} notification: ${notification.title}`}
+      onClick={handleActivate}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleActivate();
+        }
+      }}
+      className={[
+        'flex items-start gap-3 px-4 py-3 w-full',
+        'cursor-pointer transition-colors duration-150',
+        'border-b border-gray-100 last:border-b-0',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-inset',
+        isRead
+          ? 'bg-white hover:bg-gray-50'
+          : 'bg-orange-50 hover:bg-orange-100',
+      ].join(' ')}
+    >
+
+      <span
+        aria-hidden="true"
+        data-testid="unread-dot"
+        className={[
+          'shrink-0 mt-2 w-2 h-2 rounded-full',
+          isRead ? 'invisible' : 'bg-orange-500',
+        ].join(' ')}
+      />
+
+      <div
+        data-testid="icon-wrapper"
+        className={`shrink-0 flex items-center justify-center w-8 h-8 rounded-full ${wrapperBg}`}
+        aria-hidden="true"
+      >
+        {icon}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <p
+          data-testid="notification-title"
+          className={[
+            'text-sm text-gray-900 truncate',
+            isRead ? 'font-medium' : 'font-bold',
+          ].join(' ')}
+        >
+          {notification.title}
+        </p>
+        <p className="text-sm text-gray-500 mt-0.5 line-clamp-2">
+          {notification.message}
+        </p>
+        <time
+          dateTime={notification.time}
+          title={absolute ?? undefined}
+          className="block mt-1 text-xs text-gray-400 hover:text-gray-600 cursor-help"
+        >
+          {relative}
+        </time>
+      </div>
+
+      {notification.hasArrow && (
+        <svg
+          aria-hidden="true"
+          className="shrink-0 mt-1 w-4 h-4 text-gray-400"
+          fill="none"
+          viewBox="0 0 16 16"
+        >
+          <path
+            d="M6 4l4 4-4 4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/src/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/src/components/notifications/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NotificationItem } from '../NotificationItem';
+import type { Notification } from '../../../types/notifications';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const escrowNotification: Notification = {
+  id: 'notif-001',
+  type: 'ESCROW_FUNDED',
+  title: 'Escrow Funded',
+  message: 'Your escrow has been funded and is ready.',
+  time: '2026-03-24T10:00:00.000Z',
+  hasArrow: true,
+  metadata: { resourceId: 'adoption-001' },
+};
+
+const disputeNotification: Notification = {
+  id: 'notif-002',
+  type: 'DISPUTE_RAISED',
+  title: 'Dispute Raised',
+  message: 'A dispute has been opened on your adoption.',
+  time: '2026-03-24T14:00:00.000Z',
+  hasArrow: true,
+  metadata: { resourceId: 'dispute-001' },
+};
+
+const approvalNotification: Notification = {
+  id: 'notif-003',
+  type: 'APPROVAL_REQUESTED',
+  title: 'Approval Requested',
+  message: 'Someone is waiting for your approval.',
+  time: '2026-03-24T11:30:00.000Z',
+  hasArrow: true,
+  metadata: { resourceId: 'adoption-002' },
+};
+
+const documentNotification: Notification = {
+  id: 'notif-004',
+  type: 'DOCUMENT_EXPIRING',
+  title: 'Document Expiring Soon',
+  message: 'Your certificate expires in 7 days.',
+  time: '2026-03-25T08:00:00.000Z',
+  hasArrow: false,
+  metadata: { resourceId: 'adoption-001' },
+};
+
+const legacyNotification: Notification = {
+  id: 5,
+  type: 'success',
+  title: 'Payment Successful',
+  message: 'Your payment has been confirmed.',
+  time: '2 min ago',
+  hasArrow: false,
+};
+
+function renderItem(
+  notification: Notification,
+  isRead: boolean,
+  onRead = vi.fn(),
+) {
+  return render(
+    <NotificationItem
+      notification={notification}
+      isRead={isRead}
+      onRead={onRead}
+    />,
+  );
+}
+
+describe('NotificationItem', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  describe('unread state', () => {
+    it('applies orange background when isRead is false', () => {
+      const { container } = renderItem(escrowNotification, false);
+      const row = container.firstChild as HTMLElement;
+      expect(row.className).toContain('bg-orange-50');
+    });
+
+    it('renders title in bold when unread', () => {
+      renderItem(escrowNotification, false);
+      const title = screen.getByTestId('notification-title');
+      expect(title.className).toContain('font-bold');
+      expect(title.className).not.toContain('font-medium');
+    });
+
+    it('shows the unread dot when isRead is false', () => {
+      renderItem(escrowNotification, false);
+      const dot = screen.getByTestId('unread-dot');
+      expect(dot.className).toContain('bg-orange-500');
+      expect(dot.className).not.toContain('invisible');
+    });
+
+    it('exposes aria-label that includes "Unread"', () => {
+      renderItem(escrowNotification, false);
+      const button = screen.getByRole('button');
+      expect(button.getAttribute('aria-label')).toContain('Unread');
+    });
+  });
+
+  describe('read state', () => {
+    it('applies white background when isRead is true', () => {
+      const { container } = renderItem(escrowNotification, true);
+      const row = container.firstChild as HTMLElement;
+      expect(row.className).toContain('bg-white');
+      expect(row.className).not.toContain('bg-orange-50');
+    });
+
+    it('renders title with regular weight when read', () => {
+      renderItem(escrowNotification, true);
+      const title = screen.getByTestId('notification-title');
+      expect(title.className).toContain('font-medium');
+      expect(title.className).not.toContain('font-bold');
+    });
+
+    it('hides the unread dot when isRead is true', () => {
+      renderItem(escrowNotification, true);
+      const dot = screen.getByTestId('unread-dot');
+      expect(dot.className).toContain('invisible');
+    });
+
+    it('exposes aria-label that includes "Read"', () => {
+      renderItem(escrowNotification, true);
+      const button = screen.getByRole('button');
+      expect(button.getAttribute('aria-label')).toContain('Read');
+    });
+  });
+
+  describe('click behaviour', () => {
+    it('calls onRead with the notification id on click', () => {
+      const onRead = vi.fn();
+      renderItem(escrowNotification, false, onRead);
+      fireEvent.click(screen.getByRole('button'));
+      expect(onRead).toHaveBeenCalledTimes(1);
+      expect(onRead).toHaveBeenCalledWith('notif-001');
+    });
+
+    it('navigates via notificationRouter on click', () => {
+      renderItem(escrowNotification, false);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/adoption/adoption-001/settlement');
+    });
+
+    it('calls onRead before navigating (order matters)', () => {
+      const callOrder: string[] = [];
+      const onRead = vi.fn(() => callOrder.push('onRead'));
+      mockNavigate.mockImplementation(() => callOrder.push('navigate'));
+
+      renderItem(escrowNotification, false, onRead);
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(callOrder).toEqual(['onRead', 'navigate']);
+    });
+
+    it('navigates to dispute route for DISPUTE_RAISED type', () => {
+      renderItem(disputeNotification, false);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockNavigate).toHaveBeenCalledWith('/disputes/dispute-001');
+    });
+
+    it('navigates to approval route for APPROVAL_REQUESTED type', () => {
+      renderItem(approvalNotification, false);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockNavigate).toHaveBeenCalledWith('/adoption/adoption-002#approvals');
+    });
+
+    it('falls back to /notifications for unrouted types', () => {
+      renderItem(legacyNotification, false);
+      fireEvent.click(screen.getByRole('button'));
+      expect(mockNavigate).toHaveBeenCalledWith('/notifications');
+    });
+  });
+
+  describe('keyboard activation', () => {
+    it('triggers onRead and navigate when Enter is pressed', () => {
+      const onRead = vi.fn();
+      renderItem(escrowNotification, false, onRead);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+      expect(onRead).toHaveBeenCalledWith('notif-001');
+      expect(mockNavigate).toHaveBeenCalledWith('/adoption/adoption-001/settlement');
+    });
+
+    it('triggers onRead and navigate when Space is pressed', () => {
+      const onRead = vi.fn();
+      renderItem(escrowNotification, false, onRead);
+      fireEvent.keyDown(screen.getByRole('button'), { key: ' ' });
+      expect(onRead).toHaveBeenCalledWith('notif-001');
+      expect(mockNavigate).toHaveBeenCalledWith('/adoption/adoption-001/settlement');
+    });
+
+    it('does NOT trigger on other keys', () => {
+      const onRead = vi.fn();
+      renderItem(escrowNotification, false, onRead);
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Tab' });
+      expect(onRead).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('icon mapping (templateId → type)', () => {
+    it('uses teal icon wrapper for ESCROW_FUNDED (chain icon)', () => {
+      renderItem(escrowNotification, false);
+      const wrapper = screen.getByTestId('icon-wrapper');
+      expect(wrapper.className).toContain('bg-teal-100');
+    });
+
+    it('uses red icon wrapper for DISPUTE_RAISED (alert icon)', () => {
+      renderItem(disputeNotification, false);
+      const wrapper = screen.getByTestId('icon-wrapper');
+      expect(wrapper.className).toContain('bg-red-100');
+    });
+
+    it('uses green icon wrapper for APPROVAL_REQUESTED (check icon)', () => {
+      renderItem(approvalNotification, false);
+      const wrapper = screen.getByTestId('icon-wrapper');
+      expect(wrapper.className).toContain('bg-green-100');
+    });
+
+    it('uses amber icon wrapper for DOCUMENT_EXPIRING (clock icon)', () => {
+      renderItem(documentNotification, false);
+      const wrapper = screen.getByTestId('icon-wrapper');
+      expect(wrapper.className).toContain('bg-amber-100');
+    });
+
+    it('uses gray icon wrapper for unmapped legacy types (bell icon)', () => {
+      renderItem(legacyNotification, false);
+      const wrapper = screen.getByTestId('icon-wrapper');
+      expect(wrapper.className).toContain('bg-gray-100');
+    });
+  });
+
+  describe('timestamp display', () => {
+    it('shows relative time from an ISO timestamp', () => {
+      const recentTime = new Date(Date.now() - 5 * 60_000).toISOString();
+      const notification: Notification = { ...escrowNotification, time: recentTime };
+      renderItem(notification, false);
+      const timeEl = screen.getByRole('button').querySelector('time');
+      expect(timeEl?.textContent).toMatch(/\d+ minutes? ago|just now/);
+    });
+
+    it('adds an absolute time as the title tooltip for ISO timestamps', () => {
+      renderItem(escrowNotification, false);
+      const timeEl = screen.getByRole('button').querySelector('time');
+      expect(timeEl?.hasAttribute('title')).toBe(true);
+      expect(timeEl?.getAttribute('title')).not.toBe('');
+    });
+
+    it('sets dateTime attribute to the raw time value', () => {
+      renderItem(escrowNotification, false);
+      const timeEl = screen.getByRole('button').querySelector('time');
+      expect(timeEl?.getAttribute('dateTime')).toBe('2026-03-24T10:00:00.000Z');
+    });
+
+    it('displays plain-string time as-is without a tooltip', () => {
+      renderItem(legacyNotification, false);
+      const timeEl = screen.getByRole('button').querySelector('time');
+      expect(timeEl?.textContent).toBe('2 min ago');
+      expect(timeEl?.hasAttribute('title')).toBe(false);
+    });
+  });
+
+  describe('content rendering', () => {
+    it('renders the notification title', () => {
+      renderItem(escrowNotification, false);
+      expect(screen.getByText('Escrow Funded')).toBeTruthy();
+    });
+
+    it('renders the notification message', () => {
+      renderItem(escrowNotification, false);
+      expect(screen.getByText('Your escrow has been funded and is ready.')).toBeTruthy();
+    });
+
+    it('renders a chevron when hasArrow is true', () => {
+      const { container } = renderItem(escrowNotification, false);
+      const svg = container.querySelector('svg[aria-hidden="true"]:last-of-type');
+      expect(svg).toBeTruthy();
+    });
+
+    it('does NOT render a chevron when hasArrow is false', () => {
+      const { container } = renderItem(documentNotification, false);
+      const row = container.firstChild as HTMLElement;
+      const svgs = row.querySelectorAll('svg');
+      expect(svgs.length).toBe(1);
+    });
+  });
+});

--- a/src/components/notifications/index.ts
+++ b/src/components/notifications/index.ts
@@ -1,0 +1,2 @@
+export { NotificationItem } from './NotificationItem';
+export type { NotificationItemProps } from './NotificationItem';


### PR DESCRIPTION

<img width="1344" height="712" alt="Screenshot 2026-03-28 141616" src="https://github.com/user-attachments/assets/c6e1ca60-1ccd-4947-8eeb-d56bca8ad668" />
<img width="1230" height="571" alt="Screenshot 2026-03-28 144642" src="https://github.com/user-attachments/assets/cdae2671-b732-4e73-b7e5-80b884e2ee29" />
Closes #227

Implements the NotificationItem component as specified in the Notification UI epic.

## Changes

**New files**
- `src/components/notifications/NotificationItem.tsx` — single notification row component
- `src/components/notifications/index.ts` — barrel export
- `src/components/notifications/__tests__/NotificationItem.test.tsx` — 30 unit tests

**Modified files**
- `src/types/notifications.ts` — added `isRead?: boolean` to `Notification` interface
- `src/mocks/handlers/notify.ts` — seed data now includes `isRead`; PATCH and POST read handlers now mutate in-memory state
- `src/pages/notificationPage.tsx` — refactored to fetch from `/api/notifications`, render via `NotificationItem`, manage optimistic read state
- `src/api/custodyService.ts` — resolved merge conflict from `feat/custody-timeline-page`

## What the component does

- Accepts `notification: Notification`, `isRead: boolean`, `onRead: (id) => void`
- Maps `notification.type` to icon: escrow/settlement → chain (teal), dispute → alert (red), approval → check (green), document/custody → clock (amber), fallback → bell (gray)
- Unread: `bg-orange-50` background, bold title, visible orange dot indicator
- Read: `bg-white` background, regular weight title, invisible dot (no layout shift)
- Relative timestamp computed from ISO strings; absolute time shown on hover via `<time title>`
- Clicking the row calls `onRead(id)` first, then navigates via `notificationRouter(notification)`
- Full keyboard support: Enter and Space trigger the same behaviour as click

## Tests — 30/30 passing

- Unread vs read styles (background, font weight, dot visibility, aria-label)
- Click calls `onRead` before `navigate` — order explicitly tested
- Navigation routes correct for all notification types
- Keyboard activation (Enter, Space, no-op on other keys)
- Icon mapping for all 5 type groups
- ISO timestamp → relative label + tooltip; plain string → rendered as-is, no tooltip
- Chevron renders only when `hasArrow` is true