### PR TITLE
feat: add UploadQuotaIndicator component (#265)

### DIFF
--- a/src/components/ui/UploadQuotaIndicator.test.tsx
+++ b/src/components/ui/UploadQuotaIndicator.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { UploadQuotaIndicator } from './UploadQuotaIndicator'
+
+const MB = 1024 * 1024
+
+describe('UploadQuotaIndicator — color thresholds', () => {
+  it('renders green bar when usage is below 80%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={70 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-green-500')
+  })
+
+  it('renders amber bar at exactly 80%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={80 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-amber-500')
+  })
+
+  it('renders amber bar between 80% and 95%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={90 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-amber-500')
+  })
+
+  it('renders red bar at exactly 95%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={95 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-red-500')
+  })
+
+  it('renders red bar above 95%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={99 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-red-500')
+  })
+
+  it('renders red bar at 100%', () => {
+    const { container } = render(
+      <UploadQuotaIndicator usedBytes={100 * MB} totalBytes={100 * MB} />
+    )
+    const bar = container.querySelector('[role="progressbar"] > div')
+    expect(bar?.className).toContain('bg-red-500')
+  })
+})
+
+describe('UploadQuotaIndicator — text formatting', () => {
+  it('displays whole MB numbers without decimals', () => {
+    render(<UploadQuotaIndicator usedBytes={50 * MB} totalBytes={100 * MB} />)
+    expect(screen.getByText('50 MB of 100 MB used')).toBeTruthy()
+  })
+
+  it('displays fractional MB with one decimal place', () => {
+    render(<UploadQuotaIndicator usedBytes={1.5 * MB} totalBytes={10 * MB} />)
+    expect(screen.getByText('1.5 MB of 10 MB used')).toBeTruthy()
+  })
+
+  it('displays 0 MB when nothing is used', () => {
+    render(<UploadQuotaIndicator usedBytes={0} totalBytes={100 * MB} />)
+    expect(screen.getByText('0 MB of 100 MB used')).toBeTruthy()
+  })
+})
+
+describe('UploadQuotaIndicator — progressbar aria attributes', () => {
+  it('sets aria-valuenow to the current percentage', () => {
+    render(<UploadQuotaIndicator usedBytes={75 * MB} totalBytes={100 * MB} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.getAttribute('aria-valuenow')).toBe('75')
+  })
+
+  it('caps aria-valuenow at 100 when over limit', () => {
+    render(<UploadQuotaIndicator usedBytes={110 * MB} totalBytes={100 * MB} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar.getAttribute('aria-valuenow')).toBe('100')
+  })
+})
+
+describe('UploadQuotaIndicator — upload button disabled at 100%', () => {
+  it('does not render a button when onUpload is not provided', () => {
+    render(<UploadQuotaIndicator usedBytes={50 * MB} totalBytes={100 * MB} />)
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders an enabled button below quota', () => {
+    const onUpload = vi.fn()
+    render(
+      <UploadQuotaIndicator
+        usedBytes={50 * MB}
+        totalBytes={100 * MB}
+        onUpload={onUpload}
+      />
+    )
+    const button = screen.getByRole('button')
+    expect(button).not.toBeDisabled()
+    fireEvent.click(button)
+    expect(onUpload).toHaveBeenCalledOnce()
+  })
+
+  it('disables the button at exactly 100%', () => {
+    render(
+      <UploadQuotaIndicator
+        usedBytes={100 * MB}
+        totalBytes={100 * MB}
+        onUpload={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('button')).toBeDisabled()
+  })
+
+  it('does not fire onUpload when disabled at 100%', () => {
+    const onUpload = vi.fn()
+    render(
+      <UploadQuotaIndicator
+        usedBytes={100 * MB}
+        totalBytes={100 * MB}
+        onUpload={onUpload}
+      />
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onUpload).not.toHaveBeenCalled()
+  })
+
+  it('shows tooltip text "Upload limit reached" when at capacity', () => {
+    render(
+      <UploadQuotaIndicator
+        usedBytes={100 * MB}
+        totalBytes={100 * MB}
+        onUpload={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('tooltip')).toBeTruthy()
+    expect(screen.getByText('Upload limit reached')).toBeTruthy()
+  })
+
+  it('does not show tooltip when below capacity', () => {
+    render(
+      <UploadQuotaIndicator
+        usedBytes={50 * MB}
+        totalBytes={100 * MB}
+        onUpload={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('respects a custom uploadLabel', () => {
+    render(
+      <UploadQuotaIndicator
+        usedBytes={10 * MB}
+        totalBytes={100 * MB}
+        onUpload={vi.fn()}
+        uploadLabel="Add Files"
+      />
+    )
+    expect(screen.getByRole('button', { name: 'Add Files' })).toBeTruthy()
+  })
+})

--- a/src/components/ui/UploadQuotaIndicator.tsx
+++ b/src/components/ui/UploadQuotaIndicator.tsx
@@ -1,0 +1,77 @@
+interface UploadQuotaIndicatorProps {
+  usedBytes: number;
+  totalBytes: number;
+  onUpload?: () => void;
+  uploadLabel?: string;
+}
+
+function formatMB(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  return mb % 1 === 0 ? mb.toFixed(0) : mb.toFixed(1);
+}
+
+function getBarColor(percentage: number): string {
+  if (percentage >= 95) return 'bg-red-500';
+  if (percentage >= 80) return 'bg-amber-500';
+  return 'bg-green-500';
+}
+
+export function UploadQuotaIndicator({
+  usedBytes,
+  totalBytes,
+  onUpload,
+  uploadLabel = 'Upload',
+}: UploadQuotaIndicatorProps) {
+  const percentage = totalBytes > 0 ? Math.min((usedBytes / totalBytes) * 100, 100) : 0;
+  const isAtCapacity = percentage >= 100;
+  const barColor = getBarColor(percentage);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="w-full h-2 bg-gray-200 rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={Math.round(percentage)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Upload quota"
+      >
+        <div
+          className={`h-full rounded-full transition-all duration-300 ${barColor}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+
+      <p className="text-sm text-gray-600">
+        {formatMB(usedBytes)} MB of {formatMB(totalBytes)} MB used
+      </p>
+
+      {onUpload !== undefined && (
+        <div className="relative group inline-block">
+          <button
+            type="button"
+            onClick={isAtCapacity ? undefined : onUpload}
+            disabled={isAtCapacity}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 ${
+              isAtCapacity
+                ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                : 'bg-[#E84D2A] text-white hover:bg-[#c43e20] active:scale-[0.98]'
+            }`}
+          >
+            {uploadLabel}
+          </button>
+
+          {isAtCapacity && (
+            <div
+              role="tooltip"
+              className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-800 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+            >
+              Upload limit reached
+              <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #265 
Implements the `UploadQuotaIndicator` component as part of the File Verification UI epic.

- Accepts `usedBytes` and `totalBytes` props; converts to MB for display
- Progress bar color thresholds: green <80%, amber 80–95%, red ≥95%
- Text label: `"X MB of Y MB used"`
- Optional `onUpload` prop renders an upload button that is disabled at 100% capacity with an `"Upload limit reached"` tooltip
- `aria-valuenow/min/max` on the progress bar for accessibility

## Test plan

- [x] 18 unit tests covering all color thresholds (green/amber/red boundaries)
- [x] Text formatting (whole MB, fractional MB, zero usage)
- [x] `aria-valuenow` correctness and capping at 100
- [x] Button enabled below quota, disabled at exactly 100%
- [x] `onUpload` not called when disabled
- [x] Tooltip present only when at capacity
- [x] Custom `uploadLabel` respected
- [x] All 18 tests pass (`vitest run`)