### PR TITLE
Feat/admin file verification UI

### DIFF
--- a/src/api/documentService.ts
+++ b/src/api/documentService.ts
@@ -1,0 +1,15 @@
+import { apiClient } from "../lib/api-client";
+import type { AdoptionDocument, ReviewDocumentPayload } from "../types/document";
+
+export const documentService = {
+  async getAdoptionDocuments(adoptionId: string): Promise<AdoptionDocument[]> {
+    return apiClient.get(`/adoption/${adoptionId}/documents`);
+  },
+
+  async reviewDocument(
+    documentId: string,
+    payload: ReviewDocumentPayload,
+  ): Promise<AdoptionDocument> {
+    return apiClient.patch(`/documents/${documentId}/review`, payload);
+  },
+};

--- a/src/components/adoption/AdminDocumentReviewPanel.tsx
+++ b/src/components/adoption/AdminDocumentReviewPanel.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from "react";
+import { useRoleGuard } from "../../hooks/useRoleGuard";
+import { useApiQuery } from "../../hooks/useApiQuery";
+import { useMutateReviewDocument } from "../../hooks/useMutateReviewDocument";
+import { documentService } from "../../api/documentService";
+import { DocumentIntegrityBadge } from "../ui/DocumentIntegrityBadge";
+import type { AdoptionDocument } from "../../types/document";
+
+interface AdminDocumentReviewPanelProps {
+  adoptionId: string;
+}
+
+const statusClasses: Record<AdoptionDocument["reviewStatus"], string> = {
+  PENDING: "bg-amber-100 text-amber-800",
+  APPROVED: "bg-green-100 text-green-800",
+  REJECTED: "bg-red-100 text-red-800",
+};
+
+export function AdminDocumentReviewPanel({ adoptionId }: AdminDocumentReviewPanelProps) {
+  const { isAdmin } = useRoleGuard();
+  const { mutateReviewDocument, isPending } = useMutateReviewDocument(adoptionId);
+  const [documents, setDocuments] = useState<AdoptionDocument[]>([]);
+  const [rejectingDocumentId, setRejectingDocumentId] = useState<string | null>(null);
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
+
+  const { data, isLoading, isError } = useApiQuery<AdoptionDocument[]>(
+    ["adoption", adoptionId, "documents"],
+    () => documentService.getAdoptionDocuments(adoptionId),
+    { enabled: Boolean(adoptionId) },
+  );
+
+  useEffect(() => {
+    if (data) {
+      setDocuments(data);
+    }
+  }, [data]);
+
+  const approvedCount = useMemo(
+    () => documents.filter((doc) => doc.reviewStatus === "APPROVED").length,
+    [documents],
+  );
+  const totalCount = documents.length;
+  const allApproved = totalCount > 0 && approvedCount === totalCount;
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  const updateDocument = (updated: AdoptionDocument) => {
+    setDocuments((current) =>
+      current.map((doc) => (doc.id === updated.id ? updated : doc)),
+    );
+  };
+
+  const handleApprove = async (documentId: string) => {
+    setActiveDocumentId(documentId);
+    try {
+      const updated = await mutateReviewDocument({
+        documentId,
+        decision: "APPROVED",
+      });
+      updateDocument(updated);
+    } finally {
+      setActiveDocumentId(null);
+    }
+  };
+
+  const handleRejectSubmit = async (documentId: string) => {
+    const reason = rejectionReason.trim();
+    if (!reason) {
+      return;
+    }
+
+    setActiveDocumentId(documentId);
+    try {
+      const updated = await mutateReviewDocument({
+        documentId,
+        decision: "REJECTED",
+        reason,
+      });
+      updateDocument(updated);
+      setRejectingDocumentId(null);
+      setRejectionReason("");
+    } finally {
+      setActiveDocumentId(null);
+    }
+  };
+
+  return (
+    <section className="rounded-xl border border-gray-200 bg-white p-5" aria-label="Document verification panel">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900">Document verification</h2>
+        <span
+          data-testid="review-progress-badge"
+          className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700"
+        >
+          {approvedCount} of {totalCount} documents approved
+        </span>
+      </div>
+
+      {allApproved ? (
+        <p
+          data-testid="all-documents-approved-message"
+          className="mt-3 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm font-medium text-green-800"
+        >
+          All documents verified — adoption can proceed to escrow
+        </p>
+      ) : null}
+
+      {isLoading ? (
+        <p className="mt-4 text-sm text-gray-500">Loading documents...</p>
+      ) : null}
+
+      {isError ? (
+        <p className="mt-4 text-sm text-red-700">Failed to load documents. Please refresh and try again.</p>
+      ) : null}
+
+      {!isLoading && !isError && documents.length === 0 ? (
+        <p className="mt-4 text-sm text-gray-500">No documents uploaded yet.</p>
+      ) : null}
+
+      <div className="mt-4 space-y-3">
+        {documents.map((document) => {
+          const isRowPending = isPending && activeDocumentId === document.id;
+          const isRejecting = rejectingDocumentId === document.id;
+
+          return (
+            <article
+              key={document.id}
+              className="rounded-lg border border-gray-200 p-3"
+              data-testid={`document-row-${document.id}`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-gray-900">{document.fileName}</p>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <DocumentIntegrityBadge
+                      onChainVerified={document.onChainVerified}
+                      anchorTxHash={document.anchorTxHash}
+                    />
+                    <span
+                      className={`rounded-full px-2 py-1 text-xs font-semibold ${statusClasses[document.reviewStatus]}`}
+                    >
+                      {document.reviewStatus}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => void handleApprove(document.id)}
+                    disabled={isRowPending || document.reviewStatus === "APPROVED"}
+                    className="rounded-md border border-green-600 px-3 py-1.5 text-sm font-semibold text-green-700 hover:bg-green-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRejectingDocumentId(document.id);
+                      setRejectionReason(document.reviewReason ?? "");
+                    }}
+                    disabled={isRowPending}
+                    className="rounded-md border border-red-600 px-3 py-1.5 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Reject with reason
+                  </button>
+                </div>
+              </div>
+
+              {isRejecting ? (
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <label htmlFor={`reject-reason-${document.id}`} className="sr-only">
+                    Rejection reason
+                  </label>
+                  <input
+                    id={`reject-reason-${document.id}`}
+                    value={rejectionReason}
+                    onChange={(event) => setRejectionReason(event.target.value)}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    placeholder="Enter rejection reason"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handleRejectSubmit(document.id)}
+                    disabled={isRowPending || rejectionReason.trim().length === 0}
+                    className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Submit rejection
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setRejectingDocumentId(null);
+                      setRejectionReason("");
+                    }}
+                    className="rounded-md border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/adoption/__tests__/AdminDocumentReviewPanel.test.tsx
+++ b/src/components/adoption/__tests__/AdminDocumentReviewPanel.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { AdminDocumentReviewPanel } from "../AdminDocumentReviewPanel";
+import type { AdoptionDocument } from "../../../types/document";
+
+vi.mock("../../../hooks/useRoleGuard", () => ({
+  useRoleGuard: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useApiQuery", () => ({
+  useApiQuery: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useMutateReviewDocument", () => ({
+  useMutateReviewDocument: vi.fn(),
+}));
+
+import { useRoleGuard } from "../../../hooks/useRoleGuard";
+import { useApiQuery } from "../../../hooks/useApiQuery";
+import { useMutateReviewDocument } from "../../../hooks/useMutateReviewDocument";
+
+const mockUseRoleGuard = vi.mocked(useRoleGuard);
+const mockUseApiQuery = vi.mocked(useApiQuery);
+const mockUseMutateReviewDocument = vi.mocked(useMutateReviewDocument);
+
+const seedDocuments: AdoptionDocument[] = [
+  {
+    id: "doc-1",
+    fileName: "identity-proof.pdf",
+    fileUrl: "https://example.com/identity-proof.pdf",
+    publicId: "adoptions/adoption-001/identity-proof",
+    mimeType: "application/pdf",
+    size: 1024,
+    uploadedById: "user-1",
+    adoptionId: "adoption-001",
+    createdAt: "2026-03-28T10:00:00.000Z",
+    updatedAt: "2026-03-28T10:00:00.000Z",
+    onChainVerified: true,
+    anchorTxHash: "tx-hash-1",
+    reviewStatus: "APPROVED",
+    reviewReason: null,
+  },
+  {
+    id: "doc-2",
+    fileName: "home-checklist.pdf",
+    fileUrl: "https://example.com/home-checklist.pdf",
+    publicId: "adoptions/adoption-001/home-checklist",
+    mimeType: "application/pdf",
+    size: 2048,
+    uploadedById: "user-1",
+    adoptionId: "adoption-001",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+    onChainVerified: null,
+    anchorTxHash: null,
+    reviewStatus: "PENDING",
+    reviewReason: null,
+  },
+];
+
+describe("AdminDocumentReviewPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseRoleGuard.mockReturnValue({
+      role: "admin",
+      isAdmin: true,
+      isUser: false,
+    });
+
+    mockUseApiQuery.mockReturnValue({
+      data: seedDocuments,
+      isLoading: false,
+      isError: false,
+      isForbidden: false,
+      isNotFound: false,
+      error: null,
+    });
+
+    mockUseMutateReviewDocument.mockReturnValue({
+      mutateReviewDocument: vi.fn(async ({ documentId, decision, reason }) => {
+        const existing = seedDocuments.find((doc) => doc.id === documentId);
+        if (!existing) {
+          throw new Error("Document not found in test seed");
+        }
+
+        return {
+          ...existing,
+          reviewStatus: decision,
+          reviewReason: decision === "REJECTED" ? (reason ?? "") : null,
+          updatedAt: "2026-03-29T00:00:00.000Z",
+        };
+      }),
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  it("is hidden for non-admin users", () => {
+    mockUseRoleGuard.mockReturnValue({
+      role: "user",
+      isAdmin: false,
+      isUser: true,
+    });
+
+    render(<AdminDocumentReviewPanel adoptionId="adoption-001" />);
+
+    expect(screen.queryByLabelText("Document verification panel")).not.toBeInTheDocument();
+  });
+
+  it("shows inline reject reason input before rejection submission", async () => {
+    const mutateReviewDocument = vi.fn(async ({ documentId, decision, reason }) => {
+      const existing = seedDocuments.find((doc) => doc.id === documentId);
+      if (!existing) {
+        throw new Error("Document not found in test seed");
+      }
+
+      return {
+        ...existing,
+        reviewStatus: decision,
+        reviewReason: reason ?? null,
+      };
+    });
+
+    mockUseMutateReviewDocument.mockReturnValue({
+      mutateReviewDocument,
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<AdminDocumentReviewPanel adoptionId="adoption-001" />);
+
+    const targetRow = screen.getByTestId("document-row-doc-2");
+    fireEvent.click(within(targetRow).getByRole("button", { name: "Reject with reason" }));
+
+    const reasonInput = within(targetRow).getByPlaceholderText("Enter rejection reason");
+    fireEvent.change(reasonInput, { target: { value: "File is blurry" } });
+    fireEvent.click(within(targetRow).getByRole("button", { name: "Submit rejection" }));
+
+    await waitFor(() => {
+      expect(mutateReviewDocument).toHaveBeenCalledWith({
+        documentId: "doc-2",
+        decision: "REJECTED",
+        reason: "File is blurry",
+      });
+    });
+  });
+
+  it("updates progress badge after approval", async () => {
+    render(<AdminDocumentReviewPanel adoptionId="adoption-001" />);
+
+    expect(screen.getByTestId("review-progress-badge").textContent).toContain(
+      "1 of 2 documents approved",
+    );
+
+    const pendingRow = screen.getByTestId("document-row-doc-2");
+    fireEvent.click(within(pendingRow).getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("review-progress-badge").textContent).toContain(
+        "2 of 2 documents approved",
+      );
+    });
+
+    expect(screen.getByTestId("all-documents-approved-message")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useMutateReviewDocument.ts
+++ b/src/hooks/useMutateReviewDocument.ts
@@ -1,0 +1,32 @@
+import { useApiMutation } from "./useApiMutation";
+import { documentService } from "../api/documentService";
+import type {
+  AdoptionDocument,
+  DocumentReviewDecision,
+} from "../types/document";
+
+interface ReviewDocumentInput {
+  documentId: string;
+  decision: DocumentReviewDecision;
+  reason?: string;
+}
+
+export function useMutateReviewDocument(adoptionId: string) {
+  const { mutateAsync, isPending, isError, error } = useApiMutation<
+    AdoptionDocument,
+    ReviewDocumentInput
+  >(
+    ({ documentId, decision, reason }: ReviewDocumentInput) =>
+      documentService.reviewDocument(documentId, { decision, reason }),
+    {
+      invalidates: [["adoption", adoptionId, "documents"]],
+    },
+  );
+
+  return {
+    mutateReviewDocument: mutateAsync,
+    isPending,
+    isError,
+    error,
+  };
+}

--- a/src/mocks/handlers/files.ts
+++ b/src/mocks/handlers/files.ts
@@ -15,6 +15,15 @@ interface Document {
 	adoptionId: string;
 	createdAt: string;
 	updatedAt: string;
+	onChainVerified: boolean | null;
+	anchorTxHash: string | null;
+	reviewStatus: "PENDING" | "APPROVED" | "REJECTED";
+	reviewReason: string | null;
+}
+
+interface ReviewDocumentPayload {
+	decision: "APPROVED" | "REJECTED";
+	reason?: string;
 }
 
 interface UploadDocumentsResponse {
@@ -36,6 +45,10 @@ const MOCK_DOCUMENTS: Document[] = [
 		adoptionId: "adoption-001",
 		createdAt: "2026-03-18T08:00:00.000Z",
 		updatedAt: "2026-03-18T08:00:00.000Z",
+		onChainVerified: true,
+		anchorTxHash: "4f5f8abf20f6cb9d88a4dd5a13f5e97a9f5a7f72f0f7d9f8cf5a6a4d91aa1142",
+		reviewStatus: "PENDING",
+		reviewReason: null,
 	},
 	{
 		id: "doc-002",
@@ -48,6 +61,10 @@ const MOCK_DOCUMENTS: Document[] = [
 		adoptionId: "adoption-001",
 		createdAt: "2026-03-18T08:30:00.000Z",
 		updatedAt: "2026-03-18T08:30:00.000Z",
+		onChainVerified: null,
+		anchorTxHash: null,
+		reviewStatus: "PENDING",
+		reviewReason: null,
 	},
 ];
 
@@ -81,6 +98,10 @@ export const filesHandlers = [
 			adoptionId: params.id as string,
 			createdAt: now,
 			updatedAt: now,
+			onChainVerified: null,
+			anchorTxHash: null,
+			reviewStatus: "PENDING",
+			reviewReason: null,
 		};
 
 		return HttpResponse.json<UploadDocumentsResponse>({
@@ -96,5 +117,26 @@ export const filesHandlers = [
 			(d) => d.adoptionId === params.id || params.id === "adoption-001",
 		);
 		return HttpResponse.json<Document[]>(docs);
+	}),
+
+	// PATCH /api/documents/:id/review — review a single document (admin)
+	http.patch("/api/documents/:id/review", async ({ request, params }) => {
+		await delay(getDelay(request));
+
+		const body = (await request.json()) as ReviewDocumentPayload;
+		const document = MOCK_DOCUMENTS.find((doc) => doc.id === params.id);
+
+		if (!document) {
+			return HttpResponse.json(
+				{ message: "Document not found" },
+				{ status: 404 },
+			);
+		}
+
+		document.reviewStatus = body.decision;
+		document.reviewReason = body.decision === "REJECTED" ? (body.reason ?? "") : null;
+		document.updatedAt = new Date().toISOString();
+
+		return HttpResponse.json<Document>(document);
 	}),
 ];

--- a/src/pages/SettlementSummaryPage.tsx
+++ b/src/pages/SettlementSummaryPage.tsx
@@ -10,6 +10,8 @@ import { EmptyState } from "../components/ui/emptyState";
 import type { EscrowStatus } from "../components/escrow/types";
 import type { EscrowOnChainStatus } from "../types/escrow";
 import type { SettlementSummary as UISettlementSummary } from "../components/escrow/types";
+import { useRoleGuard } from "../hooks/useRoleGuard";
+import { AdminDocumentReviewPanel } from "../components/adoption/AdminDocumentReviewPanel";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -76,7 +78,9 @@ export function SettlementSummaryPage({
   summary: propSummary,
   onComplete,
 }: SettlementSummaryPageProps) {
+  const { isAdmin: isAdminFromRole } = useRoleGuard();
   const { adoptionId: paramAdoptionId } = useParams<{ adoptionId: string }>();
+  const canAdminReview = isAdmin || isAdminFromRole;
 
   // If we have a prop-driven summary, we follow its status/data.
   // Otherwise, we fetch on-chain settlement details for the adoption.
@@ -121,12 +125,14 @@ export function SettlementSummaryPage({
           />
         )}
 
-        {isAdmin && escrowStatus === "FUNDED" && (
+        {canAdminReview && escrowStatus === "FUNDED" && (
           <AdoptionCompleteButton
-            isAdmin={isAdmin}
+            isAdmin={canAdminReview}
             onConfirm={onComplete || (() => {})}
           />
         )}
+
+        {adoptionId ? <AdminDocumentReviewPanel adoptionId={adoptionId} /> : null}
 
         {/* ── Status + confirmation depth ── */}
         <div className="flex flex-wrap items-center gap-3">
@@ -160,7 +166,7 @@ export function SettlementSummaryPage({
               </p>
             </div>
 
-            {isAdmin && adoptionId && (
+            {canAdminReview && adoptionId && (
               <RetryButton adoptionId={adoptionId} />
             )}
           </div>

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,0 +1,25 @@
+export type DocumentReviewStatus = "PENDING" | "APPROVED" | "REJECTED";
+
+export type DocumentReviewDecision = "APPROVED" | "REJECTED";
+
+export interface AdoptionDocument {
+  id: string;
+  fileName: string;
+  fileUrl: string;
+  publicId: string;
+  mimeType: string;
+  size: number;
+  uploadedById: string;
+  adoptionId: string;
+  createdAt: string;
+  updatedAt: string;
+  onChainVerified: boolean | null;
+  anchorTxHash: string | null;
+  reviewStatus: DocumentReviewStatus;
+  reviewReason: string | null;
+}
+
+export interface ReviewDocumentPayload {
+  decision: DocumentReviewDecision;
+  reason?: string;
+}


### PR DESCRIPTION
Closes #264 
This pull request introduces a complete admin-facing document review workflow for adoption documents, including backend API integration, UI components, hooks, and tests. Admins can now view, approve, or reject adoption documents with reasons, and see real-time updates to document status. The mock API and document types have been extended to support review status and reasons.

The most important changes are:

**Admin Document Review Feature:**

* Added the `AdminDocumentReviewPanel` React component, which allows admins to view, approve, or reject adoption documents, including inline rejection reasons and progress tracking.
* Integrated the admin review panel into the `SettlementSummaryPage`, making it visible to admins when appropriate. [[1]](diffhunk://#diff-e24088ebcb9fc62ed69a48fbf5f3789d26d6f36cec43cd6daeb9631473c692f1R13-R14) [[2]](diffhunk://#diff-e24088ebcb9fc62ed69a48fbf5f3789d26d6f36cec43cd6daeb9631473c692f1R81-R83) [[3]](diffhunk://#diff-e24088ebcb9fc62ed69a48fbf5f3789d26d6f36cec43cd6daeb9631473c692f1L124-R136) [[4]](diffhunk://#diff-e24088ebcb9fc62ed69a48fbf5f3789d26d6f36cec43cd6daeb9631473c692f1L163-R169)

**API and Data Layer:**

* Implemented the `documentService` API client with methods for fetching adoption documents and submitting document reviews.
* Created the `useMutateReviewDocument` React hook to handle review mutations and cache invalidation.

**Type Definitions and Mock API:**

* Extended the `AdoptionDocument` type and related types to include `reviewStatus`, `reviewReason`, `onChainVerified`, and `anchorTxHash`.
* Updated the mock API handlers and seed data to support document review, including PATCH endpoints and review state. [[1]](diffhunk://#diff-f39f4975c661757342d31ae890e27059fae8c874f7d4931281678cdb39c3f783R18-R26) [[2]](diffhunk://#diff-f39f4975c661757342d31ae890e27059fae8c874f7d4931281678cdb39c3f783R48-R51) [[3]](diffhunk://#diff-f39f4975c661757342d31ae890e27059fae8c874f7d4931281678cdb39c3f783R64-R67) [[4]](diffhunk://#diff-f39f4975c661757342d31ae890e27059fae8c874f7d4931281678cdb39c3f783R101-R104) [[5]](diffhunk://#diff-f39f4975c661757342d31ae890e27059fae8c874f7d4931281678cdb39c3f783R121-R141)

**Testing:**

* Added comprehensive tests for the `AdminDocumentReviewPanel`, covering visibility, approval, rejection, and UI updates.