### PR TITLE
feat: add shared EntityDetailLayout primitive (Issue #287)

### DIFF
--- a/src/components/layout/EntityDetailLayout.test.tsx
+++ b/src/components/layout/EntityDetailLayout.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EntityDetailLayout } from "./EntityDetailLayout";
+
+describe("EntityDetailLayout", () => {
+    const baseProps = {
+        title: "Adoption Case #287",
+        statusBadge: <span>Open</span>,
+        tabs: [
+            { label: "Overview", content: <div>Overview content</div> },
+            { label: "Timeline", content: <div>Timeline content</div> },
+        ],
+    };
+
+    it("renders the header title and status badge", () => {
+        render(<EntityDetailLayout {...baseProps} />);
+
+        expect(screen.getByText("Adoption Case #287")).toBeInTheDocument();
+        expect(screen.getByText("Open")).toBeInTheDocument();
+    });
+
+    it("renders first tab content by default", () => {
+        render(<EntityDetailLayout {...baseProps} />);
+
+        expect(screen.getByText("Overview content")).toBeInTheDocument();
+        expect(screen.queryByText("Timeline content")).not.toBeInTheDocument();
+    });
+
+    it("switches content when a different tab is clicked", () => {
+        render(<EntityDetailLayout {...baseProps} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Timeline" }));
+
+        expect(screen.getByText("Timeline content")).toBeInTheDocument();
+        expect(screen.queryByText("Overview content")).not.toBeInTheDocument();
+    });
+
+    it("renders side panel and applies responsive grid classes", () => {
+        render(
+            <EntityDetailLayout
+                {...baseProps}
+                sidePanel={<div>Side details</div>}
+            />,
+        );
+
+        expect(screen.getByText("Side details")).toBeInTheDocument();
+        const gridContainer = screen.getByTestId("entity-detail-grid");
+        expect(gridContainer.className).toContain("lg:grid-cols-3");
+    });
+
+    it("calls onBack when back button is clicked", () => {
+        const onBack = vi.fn();
+        render(<EntityDetailLayout {...baseProps} onBack={onBack} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Go back" }));
+        expect(onBack).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/layout/EntityDetailLayout.tsx
+++ b/src/components/layout/EntityDetailLayout.tsx
@@ -1,0 +1,79 @@
+import { type ReactNode, useState } from "react";
+
+export interface EntityDetailLayoutTab {
+    label: string;
+    content: ReactNode;
+}
+
+export interface EntityDetailLayoutProps {
+    title: ReactNode | string;
+    statusBadge: ReactNode;
+    tabs: EntityDetailLayoutTab[];
+    sidePanel?: ReactNode;
+    onBack?: () => void;
+}
+
+export function EntityDetailLayout({
+    title,
+    statusBadge,
+    tabs,
+    sidePanel,
+    onBack,
+}: EntityDetailLayoutProps) {
+    const [activeTab, setActiveTab] = useState(0);
+
+    return (
+        <section className="space-y-6">
+            <header className="flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
+                <div className="flex min-w-0 items-center gap-3">
+                    <button
+                        type="button"
+                        onClick={onBack}
+                        disabled={!onBack}
+                        aria-label="Go back"
+                        className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Back
+                    </button>
+                    <h1 className="truncate text-xl font-semibold text-slate-900">{title}</h1>
+                </div>
+
+                <div className="shrink-0">{statusBadge}</div>
+            </header>
+
+            <nav aria-label="Entity detail tabs" className="overflow-x-auto">
+                <ul className="flex min-w-max gap-2 border-b border-slate-200">
+                    {tabs.map((tab, index) => {
+                        const isActive = activeTab === index;
+
+                        return (
+                            <li key={tab.label}>
+                                <button
+                                    type="button"
+                                    onClick={() => setActiveTab(index)}
+                                    className={`px-4 py-2 text-sm font-medium transition ${isActive
+                                            ? "border-b-2 border-slate-900 text-slate-900"
+                                            : "border-b-2 border-transparent text-slate-500 hover:text-slate-700"
+                                        }`}
+                                    aria-current={isActive ? "page" : undefined}
+                                >
+                                    {tab.label}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </nav>
+
+            <div
+                data-testid="entity-detail-grid"
+                className={`grid grid-cols-1 gap-6 ${sidePanel ? "lg:grid-cols-3" : ""}`.trim()}
+            >
+                <div className={sidePanel ? "lg:col-span-2" : ""}>{tabs[activeTab]?.content}</div>
+                {sidePanel ? <aside className="lg:col-span-1">{sidePanel}</aside> : null}
+            </div>
+        </section>
+    );
+}
+
+export default EntityDetailLayout;


### PR DESCRIPTION
This pull request introduces a new `EntityDetailLayout` component, along with a comprehensive test suite to ensure its correct behavior. The component provides a flexible layout for entity detail pages, supporting a header with a title and status badge, tabbed content navigation, an optional side panel, and a back button with callback support.

**New Component Implementation:**

* Added the `EntityDetailLayout` component in `EntityDetailLayout.tsx`, featuring:
    - Header with customizable title, status badge, and optional back button that triggers an `onBack` callback.
    - Tab navigation for switching between different content sections.
    - Responsive grid layout that adjusts when a side panel is present.

**Testing:**

* Introduced a test suite in `EntityDetailLayout.test.tsx` to verify:
    - Rendering of the header, title, and status badge.
    - Default and dynamic tab content switching.
    - Responsive grid behavior when a side panel is included.
    - Functionality of the back button and its callback.
    
Closes #287 