### PR TITLE
feat: [#283] Create shared ConfirmationModal component

### DIFF
--- a/src/components/modals/ConfirmationModal.tsx
+++ b/src/components/modals/ConfirmationModal.tsx
@@ -1,71 +1,119 @@
+import { useEffect, useRef, useCallback, useId } from "react";
+
 interface ConfirmationModalProps {
   isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
   title: string;
-  message: string;
+  body: string;
   confirmLabel?: string;
   cancelLabel?: string;
-  isLoading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDangerous?: boolean;
 }
 
 export function ConfirmationModal({
   isOpen,
-  onClose,
-  onConfirm,
   title,
-  message,
+  body,
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
-  isLoading = false,
+  onConfirm,
+  onCancel,
+  isDangerous = false,
 }: ConfirmationModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
+
+
+  useEffect(() => {
+    if (isOpen) {
+      confirmButtonRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  const trapFocus = useCallback((e: KeyboardEvent) => {
+    if (!modalRef.current) return;
+
+    const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.shiftKey && document.activeElement === firstElement) {
+      e.preventDefault();
+      lastElement?.focus();
+    } else if (!e.shiftKey && document.activeElement === lastElement) {
+      e.preventDefault();
+      firstElement?.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        onCancel();
+      }
+      if (e.key === "Tab" && isOpen) {
+        trapFocus(e);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onCancel, trapFocus]);
+
   if (!isOpen) return null;
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
-      onClick={onClose}
+      onClick={onCancel}
     >
       <div
+        ref={modalRef}
         className="relative w-full max-w-[400px] rounded-2xl bg-white shadow-2xl"
         onClick={(e) => e.stopPropagation()}
-        role="dialog"
+        role="alertdialog"
         aria-modal="true"
-        aria-labelledby="confirmation-title"
+        aria-labelledby={titleId}
       >
         <div className="space-y-6 p-8">
           <div>
             <h2
-              id="confirmation-title"
+              id={titleId}
               className="mb-2 text-[24px] font-bold text-[#0D162B]"
             >
               {title}
             </h2>
-            <p className="text-[14px] leading-relaxed text-gray-500">
-              {message}
-            </p>
+            <p className="text-[14px] leading-relaxed text-gray-500">{body}</p>
           </div>
 
           <div className="flex gap-3 pt-2">
             <button
-              onClick={onClose}
-              disabled={isLoading}
-              className="flex-1 rounded-xl border-2 border-gray-800 py-3 text-[14px] font-semibold text-gray-800 transition-colors hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={onCancel}
+              className="flex-1 rounded-xl border-2 border-gray-800 py-3 text-[14px] font-semibold text-gray-800 transition-colors hover:bg-gray-50"
               type="button"
             >
               {cancelLabel}
             </button>
             <button
+              ref={confirmButtonRef}
               onClick={onConfirm}
-              disabled={isLoading}
               className={`flex-1 rounded-xl py-3 text-[14px] font-semibold text-white transition-colors ${
-                isLoading
-                  ? "cursor-not-allowed bg-gray-400"
+                isDangerous
+                  ? "bg-red-600 hover:bg-red-700"
                   : "bg-[#E84D2A] hover:bg-[#d4431f]"
               }`}
               type="button"
             >
-              {isLoading ? "Loading..." : confirmLabel}
+              {confirmLabel}
             </button>
           </div>
         </div>

--- a/src/components/modals/__tests__/ConfirmationModal.test.tsx
+++ b/src/components/modals/__tests__/ConfirmationModal.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmationModal } from "../ConfirmationModal";
+
+const mockOnConfirm = vi.fn();
+const mockOnCancel = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const defaultProps = {
+  isOpen: true,
+  title: "Delete Pet",
+  body: "Are you sure you want to delete this pet? This action cannot be undone.",
+  onConfirm: mockOnConfirm,
+  onCancel: mockOnCancel,
+};
+
+describe("ConfirmationModal", () => {
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <ConfirmationModal {...defaultProps} isOpen={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders title and body when open", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    expect(screen.getByText("Delete Pet")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Are you sure you want to delete this pet? This action cannot be undone.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when ESC key is pressed", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onCancel on ESC when modal is closed", () => {
+    render(<ConfirmationModal {...defaultProps} isOpen={false} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+
+  it("focuses the confirm button when modal opens", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+    expect(document.activeElement).toBe(confirmButton);
+  });
+
+  it("has role alertdialog", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  it("has aria-modal set to true", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("has aria-labelledby pointing to the title element", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    const dialog = screen.getByRole("alertdialog");
+    const labelledById = dialog.getAttribute("aria-labelledby");
+    expect(labelledById).toBeTruthy();
+    const titleEl = document.getElementById(labelledById!);
+    expect(titleEl?.textContent).toBe("Delete Pet");
+  });
+
+  it("confirm button has red styling when isDangerous is true", () => {
+    render(<ConfirmationModal {...defaultProps} isDangerous={true} />);
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+    expect(confirmButton.className).toContain("bg-red-600");
+  });
+
+  it("confirm button does not have red styling when isDangerous is false", () => {
+    render(<ConfirmationModal {...defaultProps} isDangerous={false} />);
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+    expect(confirmButton.className).not.toContain("bg-red-600");
+  });
+
+  it("renders custom confirmLabel and cancelLabel", () => {
+    render(
+      <ConfirmationModal
+        {...defaultProps}
+        confirmLabel="Yes, delete"
+        cancelLabel="Keep it"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /yes, delete/i }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /keep it/i })).toBeTruthy();
+  });
+
+  it("focus trap: Tab from last focusable element wraps to first", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+
+    
+    confirmButton.focus();
+    expect(document.activeElement).toBe(confirmButton);
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: false });
+    expect(document.activeElement).toBe(cancelButton);
+  });
+
+  it("focus trap: Shift+Tab from first focusable element wraps to last", () => {
+    render(<ConfirmationModal {...defaultProps} />);
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    const confirmButton = screen.getByRole("button", { name: /confirm/i });
+
+    // cancel is the first focusable element
+    cancelButton.focus();
+    expect(document.activeElement).toBe(cancelButton);
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(confirmButton);
+  });
+});

--- a/src/pages/NotificationPreferencesPage.tsx
+++ b/src/pages/NotificationPreferencesPage.tsx
@@ -143,12 +143,11 @@ export default function NotificationPreferencesPage() {
 
         <ConfirmationModal
           isOpen={showResetModal}
-          onClose={() => setShowResetModal(false)}
+          onCancel={() => setShowResetModal(false)}
           onConfirm={confirmReset}
           title="Reset Preferences"
-          message="Are you sure you want to reset all notification preferences to their default settings? This action cannot be undone."
+          body="Are you sure you want to reset all notification preferences to their default settings? This action cannot be undone."
           confirmLabel="Reset"
-          isLoading={updatePreferences.isPending}
         />
       </div>
     </div>

--- a/src/pages/__tests__/NotificationPreferencesPage.test.tsx
+++ b/src/pages/__tests__/NotificationPreferencesPage.test.tsx
@@ -109,7 +109,7 @@ describe("NotificationPreferencesPage", () => {
     fireEvent.click(screen.getByText("Reset to defaults"));
 
     expect(mockMutate).not.toHaveBeenCalled();
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
 
     fireEvent.click(screen.getByText("Reset"));
 


### PR DESCRIPTION
Closes #283

## Summary
Implements the shared `ConfirmationModal` primitive as specified in issue #283.

## Changes

### `src/components/modals/ConfirmationModal.tsx` (rewrite)
- Updated prop interface: `body`, `onCancel`, `isDangerous?` replacing the
  previous draft's `message`, `onClose`, `isLoading`
- `isDangerous=true` → confirm button renders with `bg-red-600` (destructive red)
- `isDangerous=false` (default) → confirm button uses brand colour `bg-[#E84D2A]`
- Focus moves to confirm button on open via `useRef` + `useEffect`
- ESC key calls `onCancel` via `document.addEventListener` in `useEffect`
- Focus trap implemented with `useCallback` + `querySelectorAll` cycling
  Tab / Shift+Tab within the modal
- `role="alertdialog"`, `aria-modal="true"`, `aria-labelledby` via `useId()`

### `src/components/modals/__tests__/ConfirmationModal.test.tsx` (new)
15 unit tests covering:
- `onConfirm` called on confirm button click
- `onCancel` called on cancel button click and on ESC key
- No action on ESC when modal is closed
- Focus lands on confirm button on open
- `role="alertdialog"`, `aria-modal`, `aria-labelledby` attributes
- `isDangerous=true` applies red styling; `isDangerous=false` does not
- Custom `confirmLabel` / `cancelLabel` props
- Focus trap: Tab from last element wraps to first
- Focus trap: Shift+Tab from first element wraps to last

### `src/pages/NotificationPreferencesPage.tsx` (updated)
- Migrated existing `ConfirmationModal` usage to new prop interface

### `src/pages/__tests__/NotificationPreferencesPage.test.tsx` (updated)
- Updated `getByRole("dialog")` → `getByRole("alertdialog")` to match
  the correct ARIA role now used by the component

## Test Results
- 61 test files, 486 tests — all passing
- `npm run lint` — 0 errors
- `npm run build` — clean