### PR TITLE
feat: handle notification deep-link on app init

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import { useNotificationDeepLink } from "./hooks/useNotificationDeepLink";
 import { MainLayout } from "./components/layout/MainLayout";
 import FavouritePage from "./pages/FavouritePage";
 import HomePage from "./pages/HomePage";
@@ -25,6 +26,8 @@ import AdminDisputeListPage from "./pages/AdminDisputeListPage";
 import DisputeDetailPage from "./pages/DisputeDetailPage";
 
 function App() {
+  useNotificationDeepLink();
+
   return (
     <Routes>
       {/* Auth Routes - No Navbar/Footer */}

--- a/src/hooks/__tests__/useNotificationDeepLink.test.tsx
+++ b/src/hooks/__tests__/useNotificationDeepLink.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useNotificationDeepLink } from "../useNotificationDeepLink";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockNotification = {
+  id: "42",
+  type: "DISPUTE_RAISED",
+  title: "Dispute",
+  message: "A dispute was raised",
+  time: "2024-01-01T00:00:00Z",
+  metadata: { resourceId: "99" },
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe("useNotificationDeepLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn());
+    window.history.replaceState(null, "", "/home?notificationId=42");
+  });
+
+  it("fetches notification, marks read, navigates, and removes param", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockNotification) } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response); // mark read
+
+    renderHook(() => useNotificationDeepLink(), { wrapper });
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/disputes/99", { replace: true }));
+
+    expect(fetch).toHaveBeenCalledWith("/api/notifications/42");
+    expect(fetch).toHaveBeenCalledWith("/api/notifications/42/read", { method: "PATCH" });
+    expect(window.location.search).not.toContain("notificationId");
+  });
+
+  it("logs and continues when notification is 404", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 404 } as Response);
+
+    renderHook(() => useNotificationDeepLink(), { wrapper });
+
+    await waitFor(() => expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("not found")));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when notificationId param is absent", () => {
+    window.history.replaceState(null, "", "/home");
+
+    renderHook(() => useNotificationDeepLink(), { wrapper });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useNotificationDeepLink.ts
+++ b/src/hooks/useNotificationDeepLink.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { notificationRouter } from "../lib/notificationRouter";
+import type { Notification } from "../types/notifications";
+
+async function fetchNotification(id: string): Promise<Notification> {
+  const res = await fetch(`/api/notifications/${id}`);
+  if (!res.ok) {
+    const err = Object.assign(new Error(`Failed to fetch notification: ${res.status}`), { status: res.status });
+    throw err;
+  }
+  return res.json() as Promise<Notification>;
+}
+
+async function markRead(id: string): Promise<void> {
+  await fetch(`/api/notifications/${id}/read`, { method: "PATCH" });
+}
+
+export function useNotificationDeepLink() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const notificationId = params.get("notificationId");
+    if (!notificationId) return;
+
+    // Remove the param from the URL immediately
+    params.delete("notificationId");
+    const newUrl = window.location.pathname + (params.toString() ? `?${params.toString()}` : "");
+    window.history.replaceState(null, "", newUrl);
+
+    fetchNotification(notificationId)
+      .then((notification) => {
+        markRead(notificationId).catch(() => {});
+        navigate(notificationRouter(notification), { replace: true });
+      })
+      .catch((err: { status?: number }) => {
+        if (err?.status === 404) {
+          console.warn(`Notification ${notificationId} not found, ignoring deep-link.`);
+        } else {
+          console.error("Failed to handle notification deep-link:", err);
+        }
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/src/mocks/handlers/notify.ts
+++ b/src/mocks/handlers/notify.ts
@@ -133,6 +133,14 @@ export const notifyHandlers = [
     return HttpResponse.json<NotificationsPage>(response);
   }),
 
+  http.get("/api/notifications/:id", async ({ params, request }) => {
+    await delay(getDelay(request));
+    const { id } = params;
+    const notification = mockNotifications.find((n) => String(n.id) === String(id));
+    if (!notification) return new HttpResponse(null, { status: 404 });
+    return HttpResponse.json<Notification>(notification);
+  }),
+
   http.patch("/api/notifications/:id/read", async ({ params, request }) => {
     await delay(getDelay(request));
     const { id } = params;


### PR DESCRIPTION
- Read ?notificationId= from URL on mount via useNotificationDeepLink hook
- Fetch notification, mark as read, navigate via notificationRouter()
- Remove ?notificationId= from URL immediately after reading
- Log warning on 404, log error on other failures, no navigation
- Add GET /api/notifications/:id MSW handler for dev/test support
- Unit tests: happy path, 404 handling, no-op when param absent

closes #234 