### PR TITLE
Add status filters to adoption list page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
@@ -1325,6 +1326,22 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -4374,6 +4391,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/src/components/filters/StatusFilterChips.test.tsx
+++ b/src/components/filters/StatusFilterChips.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { StatusFilterChips } from './StatusFilterChips';

--- a/src/components/filters/StatusFilterChips.test.tsx
+++ b/src/components/filters/StatusFilterChips.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StatusFilterChips } from './StatusFilterChips';
+
+const mockCounts = {
+  PENDING: 5,
+  APPROVED: 2,
+  REJECTED: 1,
+  DISPUTED: 3,
+};
+
+describe('StatusFilterChips', () => {
+  it('renders all status chips', () => {
+    render(<StatusFilterChips selectedStatuses={[]} counts={mockCounts} onChange={vi.fn()} />);
+    
+    expect(screen.getByRole('checkbox', { name: /Pending/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Approved/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Rejected/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Disputed/i })).toBeInTheDocument();
+  });
+
+  it('displays correct counts', () => {
+    render(<StatusFilterChips selectedStatuses={[]} counts={mockCounts} onChange={vi.fn()} />);
+    
+    expect(screen.getByText('5')).toBeInTheDocument(); // PENDING
+    expect(screen.getByText('2')).toBeInTheDocument(); // APPROVED
+    expect(screen.getByText('1')).toBeInTheDocument(); // REJECTED
+    expect(screen.getByText('3')).toBeInTheDocument(); // DISPUTED
+  });
+
+  it('highlights selected chips and adds appropriate aria-checked state', () => {
+    render(<StatusFilterChips selectedStatuses={['APPROVED', 'DISPUTED']} counts={mockCounts} onChange={vi.fn()} />);
+    
+    const approvedChip = screen.getByRole('checkbox', { name: /Approved/i });
+    const pendingChip = screen.getByRole('checkbox', { name: /Pending/i });
+    
+    expect(approvedChip).toHaveAttribute('aria-checked', 'true');
+    expect(pendingChip).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls onChange with added status when unselected chip is clicked', () => {
+    const mockOnChange = vi.fn();
+    render(<StatusFilterChips selectedStatuses={['PENDING']} counts={mockCounts} onChange={mockOnChange} />);
+    
+    const disputedChip = screen.getByRole('checkbox', { name: /Disputed/i });
+    fireEvent.click(disputedChip);
+    
+    expect(mockOnChange).toHaveBeenCalledWith(['PENDING', 'DISPUTED']);
+  });
+
+  it('calls onChange with removed status when selected chip is clicked', () => {
+    const mockOnChange = vi.fn();
+    render(<StatusFilterChips selectedStatuses={['PENDING', 'DISPUTED']} counts={mockCounts} onChange={mockOnChange} />);
+    
+    const disputedChip = screen.getByRole('checkbox', { name: /Disputed/i });
+    fireEvent.click(disputedChip);
+    
+    expect(mockOnChange).toHaveBeenCalledWith(['PENDING']);
+  });
+});

--- a/src/components/filters/StatusFilterChips.tsx
+++ b/src/components/filters/StatusFilterChips.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import type { AdoptionStatus } from "../../hooks/useAdoptionList";
+
+export interface StatusFilterChipsProps {
+  selectedStatuses: AdoptionStatus[];
+  counts: Record<AdoptionStatus, number>;
+  onChange: (statuses: AdoptionStatus[]) => void;
+}
+
+const STATUS_CONFIG: Record<AdoptionStatus, { label: string; color: string }> = {
+  PENDING: { label: "Pending", color: "bg-yellow-100 text-yellow-800 border-yellow-300 hover:bg-yellow-200" },
+  APPROVED: { label: "Approved", color: "bg-green-100 text-green-800 border-green-300 hover:bg-green-200" },
+  REJECTED: { label: "Rejected", color: "bg-red-100 text-red-800 border-red-300 hover:bg-red-200" },
+  DISPUTED: { label: "Disputed", color: "bg-purple-100 text-purple-800 border-purple-300 hover:bg-purple-200" },
+};
+
+const STATUS_KEYS: AdoptionStatus[] = ["PENDING", "APPROVED", "REJECTED", "DISPUTED"];
+
+export const StatusFilterChips: React.FC<StatusFilterChipsProps> = ({
+  selectedStatuses,
+  counts,
+  onChange,
+}) => {
+  const toggleStatus = (status: AdoptionStatus) => {
+    if (selectedStatuses.includes(status)) {
+      onChange(selectedStatuses.filter((s) => s !== status));
+    } else {
+      onChange([...selectedStatuses, status]);
+    }
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label="Filter adoptions by status"
+      className="flex flex-wrap gap-3 py-4"
+    >
+      {STATUS_KEYS.map((status) => {
+        const isSelected = selectedStatuses.includes(status);
+        const config = STATUS_CONFIG[status];
+        const count = counts[status] || 0;
+
+        return (
+          <button
+            key={status}
+            type="button"
+            role="checkbox"
+            aria-checked={isSelected}
+            onClick={() => toggleStatus(status)}
+            className={`
+              relative flex items-center px-4 py-2 rounded-full border text-sm font-medium transition-colors
+              focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
+              ${isSelected ? config.color : "bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-100"}
+            `}
+          >
+            {config.label}
+            <span
+              className={`
+                ml-2 inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-semibold
+                ${isSelected ? "bg-white bg-opacity-50" : "bg-gray-200 text-gray-500"}
+              `}
+            >
+              {count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/shared/Pagination/Pagination.test.tsx
+++ b/src/components/shared/Pagination/Pagination.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/src/components/shared/Pagination/Pagination.test.tsx
+++ b/src/components/shared/Pagination/Pagination.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Pagination } from './Pagination';
+
+describe('Pagination Component', () => {
+  const mockOnLoadMore = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the "Load more" button when hasNextPage is true', () => {
+    render(
+      <Pagination
+        hasNextPage={true}
+        isFetchingNextPage={false}
+        onLoadMore={mockOnLoadMore}
+      />
+    );
+    
+    const button = screen.getByRole('button', { name: /load more results/i });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('Load more');
+  });
+
+  it('does not render anything when hasNextPage is false', () => {
+    const { container } = render(
+      <Pagination
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={mockOnLoadMore}
+      />
+    );
+    
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows spinner and "Loading..." text when isFetchingNextPage is true', () => {
+    render(
+      <Pagination
+        hasNextPage={true}
+        isFetchingNextPage={true}
+        onLoadMore={mockOnLoadMore}
+      />
+    );
+    
+    const button = screen.getByRole('button', { name: /load more results/i });
+    const spinner = screen.getByTestId('pagination-spinner');
+    
+    expect(button).toHaveTextContent('Loading...');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('disables the button when isFetchingNextPage is true', () => {
+    render(
+      <Pagination
+        hasNextPage={true}
+        isFetchingNextPage={true}
+        onLoadMore={mockOnLoadMore}
+      />
+    );
+    
+    const button = screen.getByRole('button', { name: /load more results/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('triggers onLoadMore when the button is clicked', () => {
+    render(
+      <Pagination
+        hasNextPage={true}
+        isFetchingNextPage={false}
+        onLoadMore={mockOnLoadMore}
+      />
+    );
+    
+    const button = screen.getByRole('button', { name: /load more results/i });
+    fireEvent.click(button);
+    
+    expect(mockOnLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/shared/Pagination/Pagination.tsx
+++ b/src/components/shared/Pagination/Pagination.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+export interface PaginationProps {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+}
+
+export const Pagination: React.FC<PaginationProps> = ({
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+}) => {
+  if (!hasNextPage) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-center w-full py-6">
+      <button
+        onClick={onLoadMore}
+        disabled={isFetchingNextPage}
+        aria-label="Load more results"
+        className="flex items-center justify-center px-6 py-2.5 text-sm font-medium text-white transition-colors bg-blue-600 rounded-md hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+      >
+        {isFetchingNextPage ? (
+          <>
+            <svg
+              className="w-4 h-4 mr-2 text-white animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              data-testid="pagination-spinner"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Loading...
+          </>
+        ) : (
+          'Load more'
+        )}
+      </button>
+    </div>
+  );
+};

--- a/src/components/shared/Pagination/index.ts
+++ b/src/components/shared/Pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './Pagination';

--- a/src/hooks/useAdoptionList.test.ts
+++ b/src/hooks/useAdoptionList.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAdoptionList } from './useAdoptionList';
+
+describe('useAdoptionList', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initially returns isLoading as true and empty data', () => {
+    const { result } = renderHook(() => useAdoptionList({ status: [] }));
+    
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toEqual([]);
+    // Counts should be populated immediately
+    expect(result.current.counts).toEqual({
+      PENDING: 2,
+      APPROVED: 2,
+      REJECTED: 1,
+      DISPUTED: 3,
+    });
+  });
+
+  it('returns all mock data when no status filter is provided', async () => {
+    const { result } = renderHook(() => useAdoptionList({ status: [] }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toHaveLength(8); // All 8 mock items
+  });
+
+  it('filters data by a single status', async () => {
+    const { result } = renderHook(() => useAdoptionList({ status: ['DISPUTED'] }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toHaveLength(3);
+    result.current.data.forEach(item => {
+      expect(item.status).toBe('DISPUTED');
+    });
+  });
+
+  it('filters data by multiple statuses', async () => {
+    const { result } = renderHook(() => useAdoptionList({ status: ['PENDING', 'REJECTED'] }));
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toHaveLength(3); // 2 PENDING + 1 REJECTED
+    result.current.data.forEach(item => {
+      expect(['PENDING', 'REJECTED']).toContain(item.status);
+    });
+  });
+
+  it('refetches data when status changes', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useAdoptionList(props),
+      { initialProps: { status: [] as any } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    
+    expect(result.current.data).toHaveLength(8);
+
+    // Change status
+    rerender({ status: ['APPROVED'] });
+
+    expect(result.current.isLoading).toBe(true); // Should go back to loading
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toHaveLength(2); // 2 APPROVED
+  });
+});

--- a/src/hooks/useAdoptionList.test.ts
+++ b/src/hooks/useAdoptionList.test.ts
@@ -29,7 +29,7 @@ describe('useAdoptionList', () => {
     const { result } = renderHook(() => useAdoptionList({ status: [] }));
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.runAllTimers();
     });
 
     expect(result.current.isLoading).toBe(false);
@@ -40,7 +40,7 @@ describe('useAdoptionList', () => {
     const { result } = renderHook(() => useAdoptionList({ status: ['DISPUTED'] }));
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.runAllTimers();
     });
 
     expect(result.current.isLoading).toBe(false);
@@ -54,7 +54,7 @@ describe('useAdoptionList', () => {
     const { result } = renderHook(() => useAdoptionList({ status: ['PENDING', 'REJECTED'] }));
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.runAllTimers();
     });
 
     expect(result.current.isLoading).toBe(false);
@@ -71,7 +71,7 @@ describe('useAdoptionList', () => {
     );
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.runAllTimers();
     });
     
     expect(result.current.data).toHaveLength(8);
@@ -82,7 +82,7 @@ describe('useAdoptionList', () => {
     expect(result.current.isLoading).toBe(true); // Should go back to loading
 
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.runAllTimers();
     });
 
     expect(result.current.isLoading).toBe(false);

--- a/src/hooks/useAdoptionList.ts
+++ b/src/hooks/useAdoptionList.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react";
+
+export type AdoptionStatus =
+  | "PENDING"
+  | "APPROVED"
+  | "REJECTED"
+  | "DISPUTED";
+
+export interface Adoption {
+  id: string;
+  petName: string;
+  applicantName: string;
+  status: AdoptionStatus;
+  date: string;
+}
+
+const MOCK_ADOPTIONS: Adoption[] = [
+  { id: "1", petName: "Bella", applicantName: "John Doe", status: "PENDING", date: "2023-10-01" },
+  { id: "2", petName: "Max", applicantName: "Jane Smith", status: "APPROVED", date: "2023-10-02" },
+  { id: "3", petName: "Luna", applicantName: "Alice Johnson", status: "REJECTED", date: "2023-10-03" },
+  { id: "4", petName: "Charlie", applicantName: "Bob Brown", status: "DISPUTED", date: "2023-10-04" },
+  { id: "5", petName: "Milo", applicantName: "Eve White", status: "PENDING", date: "2023-10-05" },
+  { id: "6", petName: "Buddy", applicantName: "Michael Green", status: "DISPUTED", date: "2023-10-06" },
+  { id: "7", petName: "Lucy", applicantName: "Sarah Black", status: "DISPUTED", date: "2023-10-07" },
+  { id: "8", petName: "Daisy", applicantName: "Tom Clark", status: "APPROVED", date: "2023-10-08" },
+];
+
+export interface UseAdoptionListOptions {
+  status: AdoptionStatus[];
+}
+
+export interface UseAdoptionListResult {
+  data: Adoption[];
+  isLoading: boolean;
+  counts: Record<AdoptionStatus, number>;
+}
+
+export function useAdoptionList({ status }: UseAdoptionListOptions): UseAdoptionListResult {
+  const [data, setData] = useState<Adoption[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  // Compute counts dynamically based on all data (not just filtered)
+  const counts = MOCK_ADOPTIONS.reduce(
+    (acc, adoption) => {
+      acc[adoption.status] = (acc[adoption.status] || 0) + 1;
+      return acc;
+    },
+    { PENDING: 0, APPROVED: 0, REJECTED: 0, DISPUTED: 0 } as Record<AdoptionStatus, number>
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoading(true);
+
+    const timer = setTimeout(() => {
+      if (isMounted) {
+        let filtered = MOCK_ADOPTIONS;
+        if (status.length > 0) {
+          filtered = MOCK_ADOPTIONS.filter((adoption) => status.includes(adoption.status));
+        }
+        setData(filtered);
+        setIsLoading(false);
+      }
+    }, 500); // Simulate API delay
+
+    return () => {
+      isMounted = false;
+      clearTimeout(timer);
+    };
+  }, [status.join(",")]); // Re-run when status array changes
+
+  return { data, isLoading, counts };
+}

--- a/src/hooks/useAdoptionList.ts
+++ b/src/hooks/useAdoptionList.ts
@@ -57,8 +57,9 @@ export function useAdoptionList({ status }: UseAdoptionListOptions): UseAdoption
     const timer = setTimeout(() => {
       if (isMounted) {
         let filtered = MOCK_ADOPTIONS;
-        if (status.length > 0) {
-          filtered = MOCK_ADOPTIONS.filter((adoption) => status.includes(adoption.status));
+        const currentStatus = statusKey ? (statusKey.split(",") as AdoptionStatus[]) : [];
+        if (currentStatus.length > 0) {
+          filtered = MOCK_ADOPTIONS.filter((adoption) => currentStatus.includes(adoption.status));
         }
         setData(filtered);
         setIsLoading(false);
@@ -69,7 +70,7 @@ export function useAdoptionList({ status }: UseAdoptionListOptions): UseAdoption
       isMounted = false;
       clearTimeout(timer);
     };
-  }, [status, statusKey]); // Re-run when status array changes
+  }, [statusKey]); // Re-run when status array changes
 
   return { data, isLoading, counts };
 }

--- a/src/hooks/useAdoptionList.ts
+++ b/src/hooks/useAdoptionList.ts
@@ -48,6 +48,8 @@ export function useAdoptionList({ status }: UseAdoptionListOptions): UseAdoption
     { PENDING: 0, APPROVED: 0, REJECTED: 0, DISPUTED: 0 } as Record<AdoptionStatus, number>
   );
 
+  const statusKey = status.join(",");
+
   useEffect(() => {
     let isMounted = true;
     setIsLoading(true);
@@ -67,7 +69,7 @@ export function useAdoptionList({ status }: UseAdoptionListOptions): UseAdoption
       isMounted = false;
       clearTimeout(timer);
     };
-  }, [status.join(",")]); // Re-run when status array changes
+  }, [status, statusKey]); // Re-run when status array changes
 
   return { data, isLoading, counts };
 }

--- a/src/hooks/useMockPagination.ts
+++ b/src/hooks/useMockPagination.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+
+export interface UseMockPaginationResult<T> {
+  items: T[];
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+/**
+ * A mock hook to simulate cursor-based pagination with network delay.
+ * Useful for development and testing before real backend integration.
+ * 
+ * @param generateItems - Function to generate mock items for a given page/cursor
+ * @param initialTotalPages - How many pages to simulate before hasNextPage becomes false
+ * @param delayMs - Simulated network delay in milliseconds
+ */
+export function useMockPagination<T>(
+  generateItems: (pageIndex: number) => T[],
+  initialTotalPages: number = 3,
+  delayMs: number = 1000
+): UseMockPaginationResult<T> {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+  const [items, setItems] = useState<T[]>(() => generateItems(1));
+
+  const hasNextPage = currentPage < initialTotalPages;
+
+  const fetchNextPage = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    setIsFetchingNextPage(true);
+
+    // Simulate network delay
+    setTimeout(() => {
+      const nextPage = currentPage + 1;
+      const newItems = generateItems(nextPage);
+      
+      setItems((prevItems) => [...prevItems, ...newItems]);
+      setCurrentPage(nextPage);
+      setIsFetchingNextPage(false);
+    }, delayMs);
+  }, [hasNextPage, isFetchingNextPage, currentPage, generateItems, delayMs]);
+
+  return {
+    items,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  };
+}

--- a/src/pages/adoption/AdoptionListPage.test.tsx
+++ b/src/pages/adoption/AdoptionListPage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';

--- a/src/pages/adoption/AdoptionListPage.test.tsx
+++ b/src/pages/adoption/AdoptionListPage.test.tsx
@@ -39,7 +39,6 @@ describe('AdoptionListPage', () => {
   });
 
   const renderWithRouter = (initialRoute = '/adoptions') => {
-    let testLocation: Location;
     const renderResult = render(
       <MemoryRouter initialEntries={[initialRoute]}>
         <Routes>

--- a/src/pages/adoption/AdoptionListPage.test.tsx
+++ b/src/pages/adoption/AdoptionListPage.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AdoptionListPage } from './AdoptionListPage';
+import * as useAdoptionListModule from '../../hooks/useAdoptionList';
+
+// Mock the hook so we can control its return values without waiting for timeouts
+vi.mock('../../hooks/useAdoptionList', async () => {
+  const actual = await vi.importActual('../../hooks/useAdoptionList');
+  return {
+    ...actual,
+    useAdoptionList: vi.fn(),
+  };
+});
+
+const mockUseAdoptionList = vi.mocked(useAdoptionListModule.useAdoptionList);
+
+const mockCounts = {
+  PENDING: 5,
+  APPROVED: 2,
+  REJECTED: 1,
+  DISPUTED: 3,
+};
+
+const mockData: useAdoptionListModule.Adoption[] = [
+  { id: '1', petName: 'Bella', applicantName: 'John', status: 'PENDING', date: '2023-10-01' },
+  { id: '2', petName: 'Max', applicantName: 'Jane', status: 'DISPUTED', date: '2023-10-02' },
+];
+
+describe('AdoptionListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAdoptionList.mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      counts: mockCounts,
+    });
+  });
+
+  const renderWithRouter = (initialRoute = '/adoptions') => {
+    let testLocation: Location;
+    const renderResult = render(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <Routes>
+          <Route path="/adoptions" element={<AdoptionListPage />} />
+          <Route path="*" element={<AdoptionListPage />} />
+        </Routes>
+        <RoutePathLogger />
+      </MemoryRouter>
+    );
+    return renderResult;
+  };
+
+  // Helper component to extract the current URL path and search params
+  const RoutePathLogger = () => {
+    return null; // Not strictly needed, we can test URL changes via checking if the URL changes by seeing the hook args
+  };
+
+  it('renders filter chips with correct counts', () => {
+    renderWithRouter();
+    
+    expect(screen.getByRole('checkbox', { name: /Pending/i })).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument(); // PENDING count
+    
+    expect(screen.getByRole('checkbox', { name: /Disputed/i })).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument(); // DISPUTED count
+  });
+
+  it('renders the adoption list data correctly', () => {
+    renderWithRouter();
+    
+    expect(screen.getByText('Bella')).toBeInTheDocument();
+    expect(screen.getByText('Applicant: John')).toBeInTheDocument();
+    expect(screen.getByText('Max')).toBeInTheDocument();
+  });
+
+  it('updates URL query params and calls hook when a filter chip is clicked', async () => {
+    renderWithRouter('/adoptions');
+    
+    // Initially called with empty status
+    expect(mockUseAdoptionList).toHaveBeenCalledWith({ status: [] });
+
+    // Click on Disputed
+    const disputedChip = screen.getByRole('checkbox', { name: /Disputed/i });
+    fireEvent.click(disputedChip);
+
+    // It should re-render and call the hook with the updated status
+    await waitFor(() => {
+      expect(mockUseAdoptionList).toHaveBeenCalledWith({ status: ['DISPUTED'] });
+    });
+    
+    // Click on Pending
+    const pendingChip = screen.getByRole('checkbox', { name: /Pending/i });
+    fireEvent.click(pendingChip);
+
+    await waitFor(() => {
+      expect(mockUseAdoptionList).toHaveBeenCalledWith({ status: ['DISPUTED', 'PENDING'] });
+    });
+  });
+
+  it('displays empty state message reflecting selected filters', () => {
+    mockUseAdoptionList.mockReturnValue({
+      data: [],
+      isLoading: false,
+      counts: mockCounts,
+    });
+
+    renderWithRouter('/adoptions?status=DISPUTED&status=REJECTED');
+
+    const emptyStateMsg = screen.getByTestId('empty-state-message');
+    expect(emptyStateMsg).toHaveTextContent('No disputed or rejected adoptions');
+  });
+
+  it('displays default empty state when no filters are selected', () => {
+    mockUseAdoptionList.mockReturnValue({
+      data: [],
+      isLoading: false,
+      counts: mockCounts,
+    });
+
+    renderWithRouter('/adoptions');
+
+    const emptyStateMsg = screen.getByTestId('empty-state-message');
+    expect(emptyStateMsg).toHaveTextContent('No adoptions found');
+  });
+
+  it('shows loading spinner when data is loading', () => {
+    mockUseAdoptionList.mockReturnValue({
+      data: [],
+      isLoading: true,
+      counts: mockCounts,
+    });
+
+    renderWithRouter('/adoptions');
+    
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+});

--- a/src/pages/adoption/AdoptionListPage.tsx
+++ b/src/pages/adoption/AdoptionListPage.tsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import { StatusFilterChips } from "../../components/filters/StatusFilterChips";
+import { useAdoptionList, type AdoptionStatus } from "../../hooks/useAdoptionList";
+import { getStatusesFromParams, setStatusesInParams } from "../../utils/queryParams";
+
+export const AdoptionListPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Read statuses from URL
+  const selectedStatuses = useMemo(() => {
+    return getStatusesFromParams(searchParams) as AdoptionStatus[];
+  }, [searchParams]);
+
+  const { data, isLoading, counts } = useAdoptionList({ status: selectedStatuses });
+
+  // Update URL params
+  const handleFilterChange = (statuses: AdoptionStatus[]) => {
+    setSearchParams((prev) => setStatusesInParams(prev, statuses));
+  };
+
+  // Generate dynamic empty state message
+  const emptyStateMessage = useMemo(() => {
+    if (selectedStatuses.length === 0) {
+      return "No adoptions found";
+    }
+    
+    const formattedStatuses = selectedStatuses
+      .map(s => s.toLowerCase())
+      .join(" or ");
+      
+    return `No ${formattedStatuses} adoptions`;
+  }, [selectedStatuses]);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-3xl font-bold text-gray-900 mb-6">Adoption List</h1>
+      
+      <div className="mb-8">
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wider mb-2">Filter by Status</h2>
+        <StatusFilterChips
+          selectedStatuses={selectedStatuses}
+          counts={counts}
+          onChange={handleFilterChange}
+        />
+      </div>
+
+      <div>
+        {isLoading ? (
+          <div className="flex justify-center items-center py-20" data-testid="loading-spinner">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+          </div>
+        ) : data.length === 0 ? (
+          <div className="bg-gray-50 border border-dashed border-gray-300 rounded-lg py-16 px-6 text-center">
+            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m-3-3v6m5 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <h3 className="mt-2 text-sm font-medium text-gray-900" data-testid="empty-state-message">
+              {emptyStateMessage}
+            </h3>
+            <p className="mt-1 text-sm text-gray-500">
+              Try adjusting your filters to find what you're looking for.
+            </p>
+          </div>
+        ) : (
+          <div className="bg-white shadow overflow-hidden sm:rounded-md">
+            <ul className="divide-y divide-gray-200" data-testid="adoption-list">
+              {data.map((adoption) => (
+                <li key={adoption.id} className="p-4 hover:bg-gray-50 transition-colors">
+                  <div className="flex items-center justify-between">
+                    <div className="flex flex-col">
+                      <p className="text-sm font-medium text-blue-600 truncate">{adoption.petName}</p>
+                      <p className="text-sm text-gray-500">Applicant: {adoption.applicantName}</p>
+                    </div>
+                    <div className="flex flex-col items-end">
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize bg-gray-100 text-gray-800">
+                        {adoption.status.toLowerCase()}
+                      </span>
+                      <p className="text-xs text-gray-400 mt-1">{adoption.date}</p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -1,0 +1,12 @@
+export function getStatusesFromParams(params: URLSearchParams): string[] {
+  return params.getAll("status");
+}
+
+export function setStatusesInParams(params: URLSearchParams, statuses: string[]): URLSearchParams {
+  const newParams = new URLSearchParams(params);
+  newParams.delete("status");
+  statuses.forEach(status => {
+    newParams.append("status", status);
+  });
+  return newParams;
+}


### PR DESCRIPTION
Closes #157 

## Description
Implemented status filtering on the Adoption List Page using a reusable `StatusFilterChips` component. The filtering logic is fully integrated with URL query parameters and uses a mock-driven data hook for dynamic filtering and counts.

## Key Changes
- **UI Components:** Created reusable `StatusFilterChips` with active states and dynamic count badges.
- **State Management:** Integrated `useSearchParams` to persist multi-select filter states in the URL.
- **Data Layer:** Added `useAdoptionList` mock hook with simulated API delay and dynamic status counting.
- **Empty States:** Implemented dynamic empty state messages based on active filters.
- **Utilities:** Added `queryParams.ts` for clean URL parameter manipulation.
- **Testing:** Added comprehensive unit tests for the hook, UI component, and page behaviour.

## Note
- Addressed `verbatimModuleSyntax` TypeScript errors by using explicit type-only imports for `AdoptionStatus`.