### PR TITLE
feat: [#201] Create DisputeNavBadge component with role-based count polling

### DIFF
--- a/src/components/dispute/DisputeNavBadge.tsx
+++ b/src/components/dispute/DisputeNavBadge.tsx
@@ -1,0 +1,16 @@
+import { useDisputeCount } from "../../lib/hooks/useDisputeCount";
+
+export function DisputeNavBadge() {
+  const { count, displayCount } = useDisputeCount();
+
+  if (count === 0) return null;
+
+  return (
+    <span
+      aria-label={`${count} active ${count === 1 ? "dispute" : "disputes"}`}
+      className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold leading-none"
+    >
+      {displayCount}
+    </span>
+  );
+}

--- a/src/components/dispute/__tests__/DisputeNavBadge.test.tsx
+++ b/src/components/dispute/__tests__/DisputeNavBadge.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DisputeNavBadge } from "../DisputeNavBadge";
+
+const mockUseDisputeCount = vi.fn();
+
+vi.mock("../../../lib/hooks/useDisputeCount", () => ({
+  useDisputeCount: () => mockUseDisputeCount(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DisputeNavBadge", () => {
+  it("renders the count when count is greater than 0", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 3, displayCount: "3", isLoading: false });
+    render(<DisputeNavBadge />);
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("renders '9+' when count exceeds 9", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 12, displayCount: "9+", isLoading: false });
+    render(<DisputeNavBadge />);
+    expect(screen.getByText("9+")).toBeTruthy();
+  });
+
+  it("renders nothing when count is 0", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 0, displayCount: "0", isLoading: false });
+    const { container } = render(<DisputeNavBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("has an aria-label with the count for plural disputes", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 5, displayCount: "5", isLoading: false });
+    render(<DisputeNavBadge />);
+    const badge = screen.getByText("5");
+    expect(badge.getAttribute("aria-label")).toBe("5 active disputes");
+  });
+
+  it("uses singular 'dispute' in aria-label when count is 1", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 1, displayCount: "1", isLoading: false });
+    render(<DisputeNavBadge />);
+    const badge = screen.getByText("1");
+    expect(badge.getAttribute("aria-label")).toBe("1 active dispute");
+  });
+
+  it("shows '9+' in badge but reflects real count in aria-label", () => {
+    mockUseDisputeCount.mockReturnValue({ count: 15, displayCount: "9+", isLoading: false });
+    render(<DisputeNavBadge />);
+    const badge = screen.getByText("9+");
+    expect(badge.getAttribute("aria-label")).toBe("15 active disputes");
+  });
+});

--- a/src/lib/hooks/__tests__/useDisputeCount.test.tsx
+++ b/src/lib/hooks/__tests__/useDisputeCount.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useDisputeCount } from "../useDisputeCount";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUseRoleGuard = vi.fn();
+vi.mock("../../../hooks/useRoleGuard", () => ({
+  useRoleGuard: () => mockUseRoleGuard(),
+}));
+
+const mockGet = vi.fn();
+vi.mock("../../api-client", () => ({
+  apiClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+}
+
+function createWrapper(queryClient: QueryClient, initialPath = "/home") {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("useDisputeCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("admin sees total count of open and under_review disputes", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: true, isUser: false, role: "admin" });
+    // open: 2 disputes, under_review: 1 dispute → total: 3
+    mockGet
+      .mockResolvedValueOnce({ data: [{ id: "d1" }, { id: "d2" }] })
+      .mockResolvedValueOnce({ data: [{ id: "d3" }] });
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(3));
+    expect(result.current.displayCount).toBe("3");
+  });
+
+  it("admin fetches both open and under_review endpoints", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: true, isUser: false, role: "admin" });
+    mockGet
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [] });
+
+    const queryClient = createTestQueryClient();
+    renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+    expect(mockGet).toHaveBeenCalledWith("/disputes?status=open");
+    expect(mockGet).toHaveBeenCalledWith("/disputes?status=under_review");
+  });
+
+  it("user sees only their own open disputes (single endpoint)", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: false, isUser: true, role: "user" });
+    mockGet.mockResolvedValueOnce({ data: [{ id: "d1" }] });
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(1));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith("/disputes?status=open");
+  });
+
+  it("displays '9+' when count exceeds 9", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: true, isUser: false, role: "admin" });
+    // open: 7, under_review: 5 → total: 12
+    mockGet
+      .mockResolvedValueOnce({ data: Array.from({ length: 7 }, (_, i) => ({ id: `o${i}` })) })
+      .mockResolvedValueOnce({ data: Array.from({ length: 5 }, (_, i) => ({ id: `u${i}` })) });
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(12));
+    expect(result.current.displayCount).toBe("9+");
+  });
+
+  it("displays exact count when count is exactly 9", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: false, isUser: true, role: "user" });
+    mockGet.mockResolvedValueOnce({
+      data: Array.from({ length: 9 }, (_, i) => ({ id: `d${i}` })),
+    });
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(9));
+    expect(result.current.displayCount).toBe("9");
+  });
+
+  it("resets count to 0 when user visits /disputes", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: false, isUser: true, role: "user" });
+    mockGet.mockResolvedValue({ data: [] });
+
+    const queryClient = createTestQueryClient();
+    // Pre-populate cache so the reset effect has something to clear
+    queryClient.setQueryData(["dispute-count", "user"], 5);
+
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient, "/disputes"),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(0));
+  });
+
+  it("resets count to 0 when admin visits /admin/disputes", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: true, isUser: false, role: "admin" });
+    mockGet.mockResolvedValue({ data: [] });
+
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(["dispute-count", "admin"], 7);
+
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient, "/admin/disputes"),
+    });
+
+    await waitFor(() => expect(result.current.count).toBe(0));
+  });
+
+  it("does not reset count when visiting an unrelated route", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: false, isUser: true, role: "user" });
+    // refetchOnMount: false → cached value persists, no immediate fetch
+    mockGet.mockResolvedValue({ data: [] });
+
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(["dispute-count", "user"], 3);
+
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient, "/home"),
+    });
+
+    // Allow effects to settle — count must NOT be zeroed
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(result.current.count).toBe(3);
+  });
+
+  it("returns count 0 when no disputes exist", async () => {
+    mockUseRoleGuard.mockReturnValue({ isAdmin: false, isUser: true, role: "user" });
+    mockGet.mockResolvedValueOnce({ data: [] });
+
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(() => useDisputeCount(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.count).toBe(0);
+    expect(result.current.displayCount).toBe("0");
+  });
+});

--- a/src/lib/hooks/useDisputeCount.ts
+++ b/src/lib/hooks/useDisputeCount.ts
@@ -1,0 +1,53 @@
+import { useEffect, useCallback } from "react";
+import { useLocation } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../api-client";
+import { usePolling } from "./usePolling";
+import { useRoleGuard } from "../../hooks/useRoleGuard";
+import type { DisputeListResponse } from "../../types/dispute";
+
+const DISPUTE_ROUTES = ["/disputes", "/admin/disputes"];
+const POLL_INTERVAL_MS = 300_000; // 5 minutes
+const MAX_DISPLAY = 9;
+
+export function useDisputeCount() {
+  const { isAdmin } = useRoleGuard();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+
+  // Primitive string — stable across renders when role doesn't change
+  const role = isAdmin ? "admin" : "user";
+  const queryKey = ["dispute-count", role];
+
+  const fetchCount = useCallback(async (): Promise<number> => {
+    if (isAdmin) {
+      const [openRes, underReviewRes] = await Promise.all([
+        apiClient.get<DisputeListResponse>("/disputes?status=open"),
+        apiClient.get<DisputeListResponse>("/disputes?status=under_review"),
+      ]);
+      return openRes.data.length + underReviewRes.data.length;
+    }
+    // USER / SHELTER: server returns only their disputes via auth token
+    const res = await apiClient.get<DisputeListResponse>("/disputes?status=open");
+    return res.data.length;
+  }, [isAdmin]);
+
+  const query = usePolling<number>(queryKey, fetchCount, {
+    intervalMs: POLL_INTERVAL_MS,
+    pauseOnHidden: true,
+  });
+
+  // Reset count to 0 when user visits a dispute route
+  useEffect(() => {
+    if (!DISPUTE_ROUTES.includes(location.pathname)) return;
+    queryClient.setQueryData(["dispute-count", role], 0);
+  }, [location.pathname, queryClient, role]);
+
+  const count = query.data ?? 0;
+
+  return {
+    count,
+    displayCount: count > MAX_DISPLAY ? `${MAX_DISPLAY}+` : String(count),
+    isLoading: query.isLoading,
+  };
+}


### PR DESCRIPTION
Closes #201

## Summary
Implements the `DisputeNavBadge` primitive and `useDisputeCount` hook as specified in issue #201.


## Changes

### `src/lib/hooks/useDisputeCount.ts` (new)
- ADMIN: parallel fetches for `status=open` and `status=under_review`, sums counts
- USER/SHELTER (`!isAdmin`): single fetch for `status=open` (backend auth filters to own)
- Polls every 5 minutes via `usePolling` with `pauseOnHidden: true`
- Resets count to 0 via `queryClient.setQueryData` when location is `/disputes` (user) or `/admin/disputes` (admin)
- `displayCount` caps at `"9+"` when count > 9

### `src/components/dispute/DisputeNavBadge.tsx` (new)
- Renders nothing when count is 0
- `aria-label` uses real count (not capped) with correct singular/plural
- Styled consistent with existing unread dot in `NotificationCentreDropdown`

### `src/components/layout/Navbar.tsx` (modified)
- Added Disputes nav link with role-aware path
- Integrated `DisputeNavBadge` inline on the nav item

### `src/lib/hooks/__tests__/useDisputeCount.test.tsx` (new)
8 tests covering: admin total, admin API call shape, user own count,
"9+" cap, exact count, reset on /disputes, reset on /admin/disputes,
no reset on unrelated pages, initial loading state

### `src/components/dispute/__tests__/DisputeNavBadge.test.tsx` (new)
6 tests covering: renders count, renders "9+", hidden at 0,
aria-label plural, aria-label singular, aria-label uses real count

## Test Results
- All tests passing, 0 lint errors, build clean.
<img width="605" height="350" alt="image" src="https://github.com/user-attachments/assets/65194c56-a762-4f00-9c9c-0c3d7ccc2659" />
