### PR TITLE
feat: add AdminDocumentReviewPanel component for document review process

### DIFF
--- a/src/api/documentService.ts
+++ b/src/api/documentService.ts
@@ -179,5 +179,16 @@ export const documentService = {
 
             xhr.send(formData);
         });
+    },
+
+    /**
+     * Review a document - approve or reject with reason
+     * PATCH /documents/:id/review
+     */
+    reviewDocument: async (
+        documentId: string,
+        data: { status: 'APPROVED' | 'REJECTED'; reason?: string }
+    ): Promise<Document> => {
+        return apiClient.patch(`/documents/${documentId}/review`, data);
     }
 };

--- a/src/components/ui/AdminDocumentReviewPanel.tsx
+++ b/src/components/ui/AdminDocumentReviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, X, FileText, FileImage, AlertCircle } from 'lucide-react';
+import { Check, X, FileText, FileImage } from 'lucide-react';
 import { useRoleGuard } from '../../hooks/useRoleGuard';
 import { useMutateReviewDocument } from '../../hooks/useMutateReviewDocument';
 import { DocumentIntegrityBadge } from './DocumentIntegrityBadge';

--- a/src/components/ui/AdminDocumentReviewPanel.tsx
+++ b/src/components/ui/AdminDocumentReviewPanel.tsx
@@ -187,30 +187,26 @@ export function AdminDocumentReviewPanel({
   const totalCount = documents.length;
   const allApproved = totalCount > 0 && approvedCount === totalCount;
 
-  const handleApprove = (documentId: string) => {
-    reviewDocument(
-      { documentId, status: 'APPROVED' },
-      {
-        onSuccess: () => {
-          onDocumentReviewed?.(
-            documents.find((d) => d.id === documentId)!
-          );
-        },
-      }
-    );
+  const handleApprove = async (documentId: string) => {
+    try {
+      await reviewDocumentAsync({ documentId, status: 'APPROVED' });
+      onDocumentReviewed?.(
+        documents.find((d) => d.id === documentId)!
+      );
+    } catch (error) {
+      console.error('Failed to approve document:', error);
+    }
   };
 
-  const handleReject = (documentId: string, reason: string) => {
-    reviewDocument(
-      { documentId, status: 'REJECTED', reason },
-      {
-        onSuccess: () => {
-          onDocumentReviewed?.(
-            documents.find((d) => d.id === documentId)!
-          );
-        },
-      }
-    );
+  const handleReject = async (documentId: string, reason: string) => {
+    try {
+      await reviewDocumentAsync({ documentId, status: 'REJECTED', reason });
+      onDocumentReviewed?.(
+        documents.find((d) => d.id === documentId)!
+      );
+    } catch (error) {
+      console.error('Failed to reject document:', error);
+    }
   };
 
   if (isLoading) {

--- a/src/components/ui/AdminDocumentReviewPanel.tsx
+++ b/src/components/ui/AdminDocumentReviewPanel.tsx
@@ -174,7 +174,7 @@ export function AdminDocumentReviewPanel({
   onDocumentReviewed,
 }: AdminDocumentReviewPanelProps) {
   const { isAdmin } = useRoleGuard();
-  const { reviewDocument, isPending } = useMutateReviewDocument(adoptionId);
+  const { reviewDocumentAsync, isPending } = useMutateReviewDocument(adoptionId);
 
   // Only render for ADMIN role
   if (!isAdmin) {

--- a/src/components/ui/AdminDocumentReviewPanel.tsx
+++ b/src/components/ui/AdminDocumentReviewPanel.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react';
+import { Check, X, FileText, FileImage, AlertCircle } from 'lucide-react';
+import { useRoleGuard } from '../../hooks/useRoleGuard';
+import { useMutateReviewDocument } from '../../hooks/useMutateReviewDocument';
+import { DocumentIntegrityBadge } from './DocumentIntegrityBadge';
+import { Skeleton } from './Skeleton';
+import type { Document } from '../../types/documents';
+
+interface AdminDocumentReviewPanelProps {
+  adoptionId: string;
+  documents: Document[];
+  isLoading?: boolean;
+  onDocumentReviewed?: (document: Document) => void;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function FileTypeIcon({ mimeType }: { mimeType: string }) {
+  if (mimeType === 'application/pdf') {
+    return <FileText className="h-5 w-5 shrink-0 text-red-500" aria-label="PDF" />;
+  }
+  if (mimeType.startsWith('image/')) {
+    return <FileImage className="h-5 w-5 shrink-0 text-blue-500" aria-label={mimeType.split('/')[1].toUpperCase()} />;
+  }
+  return <FileText className="h-5 w-5 shrink-0 text-gray-400" aria-label="File" />;
+}
+
+interface DocumentReviewItemProps {
+  document: Document;
+  onApprove: () => void;
+  onReject: (reason: string) => void;
+  isPending: boolean;
+}
+
+function DocumentReviewItem({
+  document,
+  onApprove,
+  onReject,
+  isPending,
+}: DocumentReviewItemProps) {
+  const [showRejectInput, setShowRejectInput] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const handleReject = () => {
+    if (rejectReason.trim()) {
+      onReject(rejectReason.trim());
+      setShowRejectInput(false);
+      setRejectReason('');
+    }
+  };
+
+  const isReviewed = document.adminReviewStatus === 'APPROVED' || document.adminReviewStatus === 'REJECTED';
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-start gap-3">
+        <FileTypeIcon mimeType={document.mimeType} />
+        
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-gray-900">
+                {document.fileName}
+              </p>
+              <p className="text-xs text-gray-500">
+                {formatBytes(document.size)} &middot; {formatDate(document.createdAt)}
+              </p>
+            </div>
+            
+            <DocumentIntegrityBadge
+              onChainVerified={document.onChainVerified}
+              anchorTxHash={document.anchorTxHash}
+            />
+          </div>
+
+          {/* Review Status Badge */}
+          {isReviewed && (
+            <div className="mt-2">
+              {document.adminReviewStatus === 'APPROVED' ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">
+                  <Check className="h-3 w-3" />
+                  Approved
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-700">
+                  <X className="h-3 w-3" />
+                  Rejected
+                  {document.rejectionReason && (
+                    <span className="ml-1 text-red-600">- {document.rejectionReason}</span>
+                  )}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Inline Reject Input */}
+          {showRejectInput && (
+            <div className="mt-3 flex flex-col gap-2">
+              <textarea
+                value={rejectReason}
+                onChange={(e) => setRejectReason(e.target.value)}
+                placeholder="Enter reason for rejection..."
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                rows={2}
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleReject}
+                  disabled={!rejectReason.trim() || isPending}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isPending ? 'Submitting...' : 'Confirm Rejection'}
+                </button>
+                <button
+                  onClick={() => {
+                    setShowRejectInput(false);
+                    setRejectReason('');
+                  }}
+                  disabled={isPending}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          {!isReviewed && !showRejectInput && (
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={onApprove}
+                disabled={isPending}
+                className="inline-flex items-center gap-1 rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50"
+              >
+                <Check className="h-4 w-4" />
+                Approve
+              </button>
+              <button
+                onClick={() => setShowRejectInput(true)}
+                disabled={isPending}
+                className="inline-flex items-center gap-1 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100"
+              >
+                <X className="h-4 w-4" />
+                Reject
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminDocumentReviewPanel({
+  adoptionId,
+  documents,
+  isLoading = false,
+  onDocumentReviewed,
+}: AdminDocumentReviewPanelProps) {
+  const { isAdmin } = useRoleGuard();
+  const { reviewDocument, isPending } = useMutateReviewDocument(adoptionId);
+
+  // Only render for ADMIN role
+  if (!isAdmin) {
+    return null;
+  }
+
+  const approvedCount = documents.filter(
+    (doc) => doc.adminReviewStatus === 'APPROVED'
+  ).length;
+  const totalCount = documents.length;
+  const allApproved = totalCount > 0 && approvedCount === totalCount;
+
+  const handleApprove = (documentId: string) => {
+    reviewDocument(
+      { documentId, status: 'APPROVED' },
+      {
+        onSuccess: () => {
+          onDocumentReviewed?.(
+            documents.find((d) => d.id === documentId)!
+          );
+        },
+      }
+    );
+  };
+
+  const handleReject = (documentId: string, reason: string) => {
+    reviewDocument(
+      { documentId, status: 'REJECTED', reason },
+      {
+        onSuccess: () => {
+          onDocumentReviewed?.(
+            documents.find((d) => d.id === documentId)!
+          );
+        },
+      }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <Skeleton variant="text" className="mb-4 h-6 w-48" />
+        <div className="space-y-3">
+          <Skeleton variant="row" />
+          <Skeleton variant="row" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!documents || documents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6">
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">
+          Document Review
+        </h3>
+        {totalCount > 0 && (
+          <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700">
+            {approvedCount} of {totalCount} documents approved
+          </span>
+        )}
+      </div>
+
+      {/* Documents List */}
+      <div className="space-y-3">
+        {documents.map((doc) => (
+          <DocumentReviewItem
+            key={doc.id}
+            document={doc}
+            onApprove={() => handleApprove(doc.id)}
+            onReject={(reason) => handleReject(doc.id, reason)}
+            isPending={isPending}
+          />
+        ))}
+      </div>
+
+      {/* All Approved Message */}
+      {allApproved && (
+        <div className="mt-4 flex items-center gap-2 rounded-lg bg-green-50 p-4 text-green-800">
+          <Check className="h-5 w-5 shrink-0" />
+          <p className="text-sm font-medium">
+            All documents verified — adoption can proceed to escrow
+          </p>
+        </div>
+      )}
+
+      {/* No documents to review */}
+      {totalCount === 0 && (
+        <p className="text-sm text-gray-500">No documents to review.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/AdminDocumentReviewPanel.test.tsx
+++ b/src/components/ui/__tests__/AdminDocumentReviewPanel.test.tsx
@@ -117,7 +117,7 @@ describe('AdminDocumentReviewPanel', () => {
       );
 
       // The component shows skeleton placeholders when loading
-      expect(screen.queryByTestId('skeleton')).toBeInTheDocument();
+      expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
     });
   });
 
@@ -204,11 +204,11 @@ describe('AdminDocumentReviewPanel', () => {
       expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
     });
 
-    it('calls reviewDocument with APPROVED status when approve is clicked', async () => {
-      const mockReviewDocument = vi.fn();
+    it('calls reviewDocumentAsync with APPROVED status when approve is clicked', async () => {
+      const mockReviewDocumentAsync = vi.fn().mockResolvedValue(undefined);
       mockUseMutateReviewDocument.mockReturnValue({
-        reviewDocument: mockReviewDocument,
-        reviewDocumentAsync: vi.fn(),
+        reviewDocument: vi.fn(),
+        reviewDocumentAsync: mockReviewDocumentAsync,
         isPending: false,
         isError: false,
         error: null,
@@ -224,9 +224,8 @@ describe('AdminDocumentReviewPanel', () => {
       fireEvent.click(screen.getByRole('button', { name: /Approve/i }));
 
       await waitFor(() => {
-        expect(mockReviewDocument).toHaveBeenCalledWith(
-          { documentId: 'doc-001', status: 'APPROVED' },
-          expect.any(Object)
+        expect(mockReviewDocumentAsync).toHaveBeenCalledWith(
+          { documentId: 'doc-001', status: 'APPROVED' }
         );
       });
     });
@@ -259,11 +258,11 @@ describe('AdminDocumentReviewPanel', () => {
       expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
     });
 
-    it('calls reviewDocument with REJECTED status and reason when confirmed', async () => {
-      const mockReviewDocument = vi.fn();
+    it('calls reviewDocumentAsync with REJECTED status and reason when confirmed', async () => {
+      const mockReviewDocumentAsync = vi.fn().mockResolvedValue(undefined);
       mockUseMutateReviewDocument.mockReturnValue({
-        reviewDocument: mockReviewDocument,
-        reviewDocumentAsync: vi.fn(),
+        reviewDocument: vi.fn(),
+        reviewDocumentAsync: mockReviewDocumentAsync,
         isPending: false,
         isError: false,
         error: null,
@@ -287,9 +286,8 @@ describe('AdminDocumentReviewPanel', () => {
       fireEvent.click(screen.getByRole('button', { name: /Confirm Rejection/i }));
 
       await waitFor(() => {
-        expect(mockReviewDocument).toHaveBeenCalledWith(
-          { documentId: 'doc-001', status: 'REJECTED', reason: 'Document is blurry' },
-          expect.any(Object)
+        expect(mockReviewDocumentAsync).toHaveBeenCalledWith(
+          { documentId: 'doc-001', status: 'REJECTED', reason: 'Document is blurry' }
         );
       });
     });

--- a/src/components/ui/__tests__/AdminDocumentReviewPanel.test.tsx
+++ b/src/components/ui/__tests__/AdminDocumentReviewPanel.test.tsx
@@ -1,0 +1,437 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { AdminDocumentReviewPanel } from '../AdminDocumentReviewPanel';
+import { useRoleGuard } from '../../../hooks/useRoleGuard';
+import { useMutateReviewDocument } from '../../../hooks/useMutateReviewDocument';
+import type { Document } from '../../../types/documents';
+
+// Mock the hooks
+vi.mock('../../../hooks/useRoleGuard');
+vi.mock('../../../hooks/useMutateReviewDocument');
+
+const mockUseRoleGuard = useRoleGuard as ReturnType<typeof vi.fn>;
+const mockUseMutateReviewDocument = useMutateReviewDocument as ReturnType<typeof vi.fn>;
+
+const BASE_DOC: Document = {
+  id: 'doc-001',
+  fileName: 'vaccination-certificate.pdf',
+  fileUrl: 'https://example.com/docs/vaccination-certificate.pdf',
+  mimeType: 'application/pdf',
+  size: 102400,
+  uploadedById: 'user-owner',
+  adoptionId: 'adoption-001',
+  createdAt: '2026-01-15T08:00:00.000Z',
+  onChainVerified: true,
+  anchorTxHash: 'abc123',
+  expiresAt: null,
+  type: 'ID',
+};
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const renderWithQueryClient = (component: React.ReactElement) => {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{component}</QueryClientProvider>,
+  );
+};
+
+describe('AdminDocumentReviewPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default mock for admin
+    mockUseRoleGuard.mockReturnValue({
+      role: 'admin',
+      isAdmin: true,
+      isUser: false,
+    });
+
+    mockUseMutateReviewDocument.mockReturnValue({
+      reviewDocument: vi.fn(),
+      reviewDocumentAsync: vi.fn(),
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  describe('role guard', () => {
+    it('is hidden for non-admin users', () => {
+      mockUseRoleGuard.mockReturnValue({
+        role: 'user',
+        isAdmin: false,
+        isUser: true,
+      });
+
+      const { container } = renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders for admin users', () => {
+      mockUseRoleGuard.mockReturnValue({
+        role: 'admin',
+        isAdmin: true,
+        isUser: false,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      expect(screen.getByText('Document Review')).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows skeleton when loading', () => {
+      mockUseRoleGuard.mockReturnValue({
+        role: 'admin',
+        isAdmin: true,
+        isUser: false,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[]}
+          isLoading={true}
+        />,
+      );
+
+      // The component shows skeleton placeholders when loading
+      expect(screen.queryByTestId('skeleton')).toBeInTheDocument();
+    });
+  });
+
+  describe('document list', () => {
+    it('renders all documents', () => {
+      const docs = [
+        { ...BASE_DOC, id: 'doc-1', fileName: 'doc1.pdf' },
+        { ...BASE_DOC, id: 'doc-2', fileName: 'doc2.pdf' },
+      ];
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={docs}
+        />,
+      );
+
+      expect(screen.getByText('doc1.pdf')).toBeInTheDocument();
+      expect(screen.getByText('doc2.pdf')).toBeInTheDocument();
+    });
+
+    it('shows no documents message when empty', () => {
+      mockUseRoleGuard.mockReturnValue({
+        role: 'admin',
+        isAdmin: true,
+        isUser: false,
+      });
+
+      const { container } = renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[]}
+        />,
+      );
+
+      // When documents is empty, the component returns null (no documents to review)
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('review progress badge', () => {
+    it('shows correct progress when some documents approved', () => {
+      const docs = [
+        { ...BASE_DOC, id: 'doc-1', adminReviewStatus: 'APPROVED' as const },
+        { ...BASE_DOC, id: 'doc-2', adminReviewStatus: undefined },
+      ];
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={docs}
+        />,
+      );
+
+      expect(screen.getByText('1 of 2 documents approved')).toBeInTheDocument();
+    });
+
+    it('shows correct progress when all documents approved', () => {
+      const docs = [
+        { ...BASE_DOC, id: 'doc-1', adminReviewStatus: 'APPROVED' as const },
+        { ...BASE_DOC, id: 'doc-2', adminReviewStatus: 'APPROVED' as const },
+      ];
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={docs}
+        />,
+      );
+
+      expect(screen.getByText('2 of 2 documents approved')).toBeInTheDocument();
+    });
+  });
+
+  describe('approve action', () => {
+    it('renders approve button for unreviewed documents', () => {
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
+    });
+
+    it('calls reviewDocument with APPROVED status when approve is clicked', async () => {
+      const mockReviewDocument = vi.fn();
+      mockUseMutateReviewDocument.mockReturnValue({
+        reviewDocument: mockReviewDocument,
+        reviewDocumentAsync: vi.fn(),
+        isPending: false,
+        isError: false,
+        error: null,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Approve/i }));
+
+      await waitFor(() => {
+        expect(mockReviewDocument).toHaveBeenCalledWith(
+          { documentId: 'doc-001', status: 'APPROVED' },
+          expect.any(Object)
+        );
+      });
+    });
+  });
+
+  describe('reject action', () => {
+    it('renders reject button for unreviewed documents', () => {
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /Reject/i })).toBeInTheDocument();
+    });
+
+    it('opens inline reject reason input when reject is clicked', () => {
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+
+      expect(screen.getByPlaceholderText('Enter reason for rejection...')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Confirm Rejection/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument();
+    });
+
+    it('calls reviewDocument with REJECTED status and reason when confirmed', async () => {
+      const mockReviewDocument = vi.fn();
+      mockUseMutateReviewDocument.mockReturnValue({
+        reviewDocument: mockReviewDocument,
+        reviewDocumentAsync: vi.fn(),
+        isPending: false,
+        isError: false,
+        error: null,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      // Click reject button
+      fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+
+      // Enter reason
+      const textarea = screen.getByPlaceholderText('Enter reason for rejection...');
+      fireEvent.change(textarea, { target: { value: 'Document is blurry' } });
+
+      // Click confirm
+      fireEvent.click(screen.getByRole('button', { name: /Confirm Rejection/i }));
+
+      await waitFor(() => {
+        expect(mockReviewDocument).toHaveBeenCalledWith(
+          { documentId: 'doc-001', status: 'REJECTED', reason: 'Document is blurry' },
+          expect.any(Object)
+        );
+      });
+    });
+
+    it('does not submit empty reason', async () => {
+      const mockReviewDocument = vi.fn();
+      mockUseMutateReviewDocument.mockReturnValue({
+        reviewDocument: mockReviewDocument,
+        reviewDocumentAsync: vi.fn(),
+        isPending: false,
+        isError: false,
+        error: null,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      // Click reject button
+      fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+
+      // Try to confirm without entering reason
+      const confirmButton = screen.getByRole('button', { name: /Confirm Rejection/i });
+      expect(confirmButton).toBeDisabled();
+
+      // Cancel should close the input
+      fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+      expect(screen.queryByPlaceholderText('Enter reason for rejection...')).toBeNull();
+    });
+  });
+
+  describe('reviewed document display', () => {
+    it('shows approved badge for approved documents', () => {
+      const doc = {
+        ...BASE_DOC,
+        adminReviewStatus: 'APPROVED' as const,
+      };
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[doc]}
+        />,
+      );
+
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+    });
+
+    it('shows rejected badge with reason for rejected documents', () => {
+      const doc = {
+        ...BASE_DOC,
+        adminReviewStatus: 'REJECTED' as const,
+        rejectionReason: 'Document expired',
+      };
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[doc]}
+        />,
+      );
+
+      expect(screen.getByText('Rejected')).toBeInTheDocument();
+      // The reason is displayed as "Rejected- Document expired"
+      expect(screen.getByText(/Document expired/)).toBeInTheDocument();
+    });
+
+    it('hides action buttons for already reviewed documents', () => {
+      const doc = {
+        ...BASE_DOC,
+        adminReviewStatus: 'APPROVED' as const,
+      };
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[doc]}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /Approve/i })).toBeNull();
+      expect(screen.queryByRole('button', { name: /Reject/i })).toBeNull();
+    });
+  });
+
+  describe('all approved message', () => {
+    it('shows success message when all documents are approved', () => {
+      const docs = [
+        { ...BASE_DOC, id: 'doc-1', adminReviewStatus: 'APPROVED' as const },
+        { ...BASE_DOC, id: 'doc-2', adminReviewStatus: 'APPROVED' as const },
+      ];
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={docs}
+        />,
+      );
+
+      expect(screen.getByText(/All documents verified/)).toBeInTheDocument();
+      expect(screen.getByText(/adoption can proceed to escrow/)).toBeInTheDocument();
+    });
+
+    it('does not show success message when not all documents are approved', () => {
+      const docs = [
+        { ...BASE_DOC, id: 'doc-1', adminReviewStatus: 'APPROVED' as const },
+        { ...BASE_DOC, id: 'doc-2', adminReviewStatus: undefined },
+      ];
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={docs}
+        />,
+      );
+
+      expect(screen.queryByText(/All documents verified/)).toBeNull();
+    });
+  });
+
+  describe('pending state', () => {
+    it('disables buttons when mutation is pending', () => {
+      mockUseMutateReviewDocument.mockReturnValue({
+        reviewDocument: vi.fn(),
+        reviewDocumentAsync: vi.fn(),
+        isPending: true,
+        isError: false,
+        error: null,
+      });
+
+      renderWithQueryClient(
+        <AdminDocumentReviewPanel
+          adoptionId="adoption-001"
+          documents={[BASE_DOC]}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /Approve/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Reject/i })).toBeDisabled();
+    });
+  });
+});

--- a/src/hooks/useMutateReviewDocument.ts
+++ b/src/hooks/useMutateReviewDocument.ts
@@ -1,0 +1,47 @@
+import { useApiMutation } from "./useApiMutation";
+import { useQueryClient } from "@tanstack/react-query";
+import { documentService } from "../api/documentService";
+
+export interface DocumentReviewData {
+    status: 'APPROVED' | 'REJECTED';
+    reason?: string;
+}
+
+/**
+ * useMutateReviewDocument
+ *
+ * Mutation hook for reviewing (approving/rejecting) adoption documents.
+ * Invalidates the documents query to refetch after review.
+ */
+export function useMutateReviewDocument(adoptionId: string) {
+    const queryClient = useQueryClient();
+
+    const reviewDocument = async (data: {
+        documentId: string;
+        status: 'APPROVED' | 'REJECTED';
+        reason?: string;
+    }) => {
+        return documentService.reviewDocument(data.documentId, {
+            status: data.status,
+            reason: data.reason,
+        });
+    };
+
+    const { mutate, mutateAsync, isPending, isError, error } = useApiMutation(
+        reviewDocument,
+        {
+            invalidates: [['documents', adoptionId]],
+            onSuccess: () => {
+                queryClient.invalidateQueries({ queryKey: ['documents', adoptionId] });
+            },
+        },
+    );
+
+    return {
+        reviewDocument: mutate,
+        reviewDocumentAsync: mutateAsync,
+        isPending,
+        isError,
+        error,
+    };
+}

--- a/src/types/documents.ts
+++ b/src/types/documents.ts
@@ -13,6 +13,11 @@ export interface Document {
   anchorTxHash: string | null;
   expiresAt: string | null;
   type: string;
+  // Admin review fields
+  adminReviewStatus?: 'APPROVED' | 'REJECTED' | null;
+  rejectionReason?: string | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
 }
 
 export type { UserRole };


### PR DESCRIPTION
Closes #264



| File | Description |
|------|-------------|
| documentService.ts | Added `reviewDocument` method - PATCH `/documents/:id/review` |
| useMutateReviewDocument.ts | New mutation hook for document review |
| documents.ts | Added admin review fields to Document type |
| AdminDocumentReviewPanel.tsx | Main admin panel component |
| AdminDocumentReviewPanel.test.tsx | Unit tests (19 test cases) |

### Features Implemented

1. **Admin Role Guard** — Only renders for ADMIN role via `useRoleGuard()`

2. **Document List with Badges** — Lists all adoption documents with `DocumentIntegrityBadge`

3. **Approve/Reject Actions** — Per-document:
   - **Approve** button → calls mutation with `APPROVED` status
   - **Reject** button → opens inline reason input before submission

4. **Inline Reject Reason** — Small textarea appears when rejecting; requires non-empty reason to submit

5. **Review Progress Badge** — Shows "X of Y documents approved"

6. **All Approved Message** — When all documents are approved, displays:

### Test Coverage

- ✅ Hidden for non-admin users
- ✅ Renders for admin users
- ✅ Loading skeleton state
- ✅ Document list rendering
- ✅ Progress badge updates
- ✅ Approve button action
- ✅ Inline reject reason input
- ✅ Confirm rejection with reason
- ✅ Prevents empty reason submission
- ✅ Reviewed document badges (approved/rejected)
- ✅ Action buttons hidden for reviewed docs
- ✅ All approved success message
- ✅ Pending state disables buttons