### PR TITLE
Feat/file upload zone

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,16 +62,9 @@ function App() {
           element={<AdoptionTimelinePage />}
         />
 
-        {/* Admin Approvals */}
-        <Route
-          path="/admin/approvals"
-          element={<AdminApprovalQueuePage />}
-        />
-
-        <Route
-          path="/admin/disputes"
-          element={<AdminDisputeListPage />}
-        />
+        {/* Admin Routes */}
+        <Route path="/admin/approvals" element={<AdminApprovalQueuePage />} />
+        <Route path="/admin/disputes" element={<AdminDisputeListPage />} />
 
         <Route
           path="/disputes"

--- a/src/components/ui/FileUploadZone.tsx
+++ b/src/components/ui/FileUploadZone.tsx
@@ -1,137 +1,333 @@
-import { useState, useRef, type DragEvent, type ChangeEvent } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 
-interface FileUploadZoneProps {
-    id: string;
-    label?: string;
-    accept?: string;
-    onChange: (file: File | null) => void;
-    selectedFile: File | null;
-    error?: string;
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface FileUploadZoneProps {
+  /** Restrict accepted file types, e.g. ".pdf,.jpg,.png" */
+  accept?: string;
+  /** Maximum number of files allowed (default: 5) */
+  maxFiles?: number;
+  /** Called with the current list of valid accepted files on every change */
+  onFilesChange: (files: File[]) => void;
+  /** Optional label rendered above the zone */
+  label?: string;
 }
 
+interface FileEntry {
+  id: string;
+  file: File;
+  error: string | null;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_ACCEPT = ".pdf,.jpg,.jpeg,.png";
+const ALLOWED_MIME = new Set(["application/pdf", "image/jpeg", "image/png"]);
+const ALLOWED_EXT = /\.(pdf|jpg|jpeg|png)$/i;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function cx(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+/**
+ * Validates a file against the accepted MIME types.
+ * The `accept` prop restricts the OS picker; this is the secondary client-side guard.
+ */
+function validateMime(file: File): string | null {
+  const ok = ALLOWED_MIME.has(file.type) || ALLOWED_EXT.test(file.name);
+  return ok ? null : "Unsupported type — PDF, JPG or PNG only";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
 export function FileUploadZone({
-    id,
-    label,
-    accept = "image/*,.pdf,.doc,.docx",
-    onChange,
-    selectedFile,
-    error,
+  accept = DEFAULT_ACCEPT,
+  maxFiles = 5,
+  onFilesChange,
+  label,
 }: FileUploadZoneProps) {
-    const hiddenFileInput = useRef<HTMLInputElement>(null);
-    const [isDragOver, setIsDragOver] = useState(false);
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const [limitError, setLimitError] = useState<string | null>(null);
 
-    const handleClick = () => {
-        hiddenFileInput.current?.click();
-    };
+  const validCount = entries.filter((e) => !e.error).length;
+  const atMax = validCount >= maxFiles;
 
-    const handleFile = (file: File | undefined) => {
-        if (!file) return;
-        onChange(file);
-    };
+  // Publish only valid files to the parent
+  const publish = useCallback(
+    (next: FileEntry[]) => {
+      onFilesChange(next.filter((e) => !e.error).map((e) => e.file));
+    },
+    [onFilesChange],
+  );
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const fileUploaded = e.target.files?.[0];
-        handleFile(fileUploaded);
-        // Reset input value to allow selecting the same file again if removed
-        if (e.target) {
-            e.target.value = '';
+  const addFiles = useCallback(
+    (incoming: File[]) => {
+      setLimitError(null);
+      setEntries((prev) => {
+        const capacity = maxFiles - prev.filter((e) => !e.error).length;
+
+        if (capacity <= 0) {
+          setLimitError(`Maximum ${maxFiles} files allowed`);
+          return prev;
         }
-    };
 
-    const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsDragOver(true);
-    };
+        let slots = capacity;
+        const next = [...prev];
+        let overLimit = false;
 
-    const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsDragOver(false);
-    };
-
-    const handleDrop = (e: DragEvent<HTMLDivElement>) => {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsDragOver(false);
-
-        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-            handleFile(e.dataTransfer.files[0]);
-            e.dataTransfer.clearData();
-        }
-    };
-
-    return (
-        <div className="flex flex-col gap-1.5 w-full">
-            {label && (
-                <label htmlFor={id} className="text-[13px] font-medium text-gray-700 mb-1">
-                    {label}
-                </label>
-            )}
-
-            <div
-                onClick={handleClick}
-                onDragOver={handleDragOver}
-                onDragLeave={handleDragLeave}
-                onDrop={handleDrop}
-                className={`flex flex-col items-center justify-center w-full cursor-pointer rounded-xl border-2 border-dashed bg-white px-6 py-10 outline-none transition-all
-          ${
-              isDragOver
-                  ? "border-[#0D162B] bg-gray-50"
-                  : error
-                  ? "border-red-400 bg-red-50/10"
-                  : "border-gray-200 hover:border-gray-300"
+        for (const file of incoming) {
+          const mimeError = validateMime(file);
+          if (mimeError) {
+            next.push({ id: uid(), file, error: mimeError });
+            continue;
           }
-        `}
+          if (slots <= 0) {
+            overLimit = true;
+            continue;
+          }
+          next.push({ id: uid(), file, error: null });
+          slots--;
+        }
+
+        if (overLimit) {
+          setLimitError(`Maximum ${maxFiles} files allowed`);
+        }
+
+        publish(next);
+        return next;
+      });
+    },
+    [maxFiles, publish],
+  );
+
+  const removeEntry = useCallback(
+    (id: string) => {
+      setLimitError(null);
+      setEntries((prev) => {
+        const next = prev.filter((e) => e.id !== id);
+        publish(next);
+        return next;
+      });
+    },
+    [publish],
+  );
+
+  // ─── Event handlers ──────────────────────────────────────────────────────
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!atMax) setDragging(true);
+  };
+
+  const handleDragLeave = () => setDragging(false);
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragging(false);
+    addFiles(Array.from(e.dataTransfer.files));
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) addFiles(Array.from(e.target.files));
+    e.target.value = "";
+  };
+
+  const openBrowser = () => {
+    if (!atMax) inputRef.current?.click();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      openBrowser();
+    }
+  };
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col gap-1.5 w-full">
+      {label && (
+        <label className="text-[13px] font-medium text-gray-700">{label}</label>
+      )}
+
+      {/* Drop zone */}
+      <div
+        role="button"
+        tabIndex={atMax ? -1 : 0}
+        aria-disabled={atMax}
+        aria-label="Upload files. Drag and drop or click to browse"
+        data-testid="file-upload-zone"
+        data-dragging={dragging || undefined}
+        onClick={openBrowser}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        onKeyDown={handleKeyDown}
+        className={cx(
+          "flex flex-col items-center justify-center w-full rounded-xl border-2 border-dashed px-6 py-10 text-center outline-none",
+          "transition-[border-color,background-color] duration-150",
+          dragging
+            ? "border-orange-400 bg-orange-50/40 cursor-copy"
+            : atMax
+              ? "border-gray-200 bg-gray-50 cursor-not-allowed opacity-60"
+              : "border-gray-200 bg-white cursor-pointer hover:border-gray-300",
+          // focus-visible ring for keyboard users
+          "focus-visible:ring-2 focus-visible:ring-[#E84D2A]/40",
+        )}
+      >
+        {/* Upload icon */}
+        <svg
+          aria-hidden="true"
+          className="w-10 h-10 mb-3 text-gray-400"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
+          />
+        </svg>
+
+        <p className="text-sm text-gray-700">
+          <span className="font-semibold text-[#E84D2A]">Click to upload</span>
+          {" or drag and drop"}
+        </p>
+        <p className="text-xs text-gray-400 mt-1">PDF, JPG, PNG</p>
+      </div>
+
+      {/* Hidden file input */}
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        multiple
+        accept={accept}
+        onChange={handleInputChange}
+        className="hidden"
+        aria-hidden="true"
+        data-testid="file-input"
+      />
+
+      {/* Limit / global error */}
+      {limitError && (
+        <p role="alert" className="text-xs text-red-500 mt-0.5" data-testid="limit-error">
+          {limitError}
+        </p>
+      )}
+
+      {/* File list */}
+      {entries.length > 0 && (
+        <ul className="list-none p-0 mt-2 flex flex-col gap-2" data-testid="file-list">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              data-testid="file-entry"
+              className={cx(
+                "flex items-center gap-2.5 rounded-lg px-3 py-2.5 border",
+                entry.error
+                  ? "border-red-200 bg-red-50/40"
+                  : "border-gray-100 bg-gray-50",
+              )}
             >
-                <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-3 text-gray-500">
-                    <svg
-                        className="w-6 h-6"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        strokeWidth={1.5}
-                        stroke="currentColor"
-                    >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z" />
-                    </svg>
-                </div>
-
-                <div className="text-center">
-                    <span className="text-[14px] font-medium text-[#E84D2A] hover:underline">
-                        Click to upload
-                    </span>
-                    <span className="text-[14px] text-gray-500">
-                        {" "}or drag and drop
-                    </span>
-                </div>
-                
-                {selectedFile ? (
-                    <p className="mt-2 text-[13px] font-medium text-gray-900 border border-gray-200 rounded-md px-3 py-1.5 bg-gray-50 flex items-center gap-2">
-                        <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                        </svg>
-                        <span className="truncate max-w-[200px]">{selectedFile.name}</span>
-                    </p>
-                ) : (
-                    <p className="text-[12px] text-gray-400 mt-1">SVG, PNG, JPG or PDF (max. 10MB)</p>
+              {/* File icon */}
+              <div
+                aria-hidden="true"
+                className={cx(
+                  "w-7 h-7 rounded flex items-center justify-center shrink-0",
+                  entry.error ? "bg-red-100" : "bg-[rgba(232,77,42,0.1)]",
                 )}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={entry.error ? "#ef4444" : "#E84D2A"}
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                </svg>
+              </div>
 
-                <input
-                    id={id}
-                    type="file"
-                    accept={accept}
-                    ref={hiddenFileInput}
-                    onChange={handleChange}
-                    className="hidden"
-                    aria-invalid={!!error}
-                />
-            </div>
-
-            {error && (
-                <p className="text-xs text-red-500 mt-0.5">
-                    {error}
+              {/* Name + size / error */}
+              <div className="flex-1 min-w-0">
+                <p
+                  className="text-[13px] font-medium text-gray-900 m-0 truncate"
+                  title={entry.file.name}
+                >
+                  {entry.file.name}
                 </p>
-            )}
-        </div>
-    );
+                {entry.error ? (
+                  <p role="alert" className="text-[11px] text-red-500 mt-px mb-0">
+                    {entry.error}
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-gray-400 mt-px mb-0">
+                    {formatBytes(entry.file.size)}
+                  </p>
+                )}
+              </div>
+
+              {/* Remove button */}
+              <button
+                type="button"
+                aria-label={`Remove ${entry.file.name}`}
+                onClick={() => removeEntry(entry.id)}
+                className="bg-transparent border-none cursor-pointer p-1 text-gray-400 rounded flex items-center justify-center shrink-0 hover:text-gray-700 transition-colors"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* File counter */}
+      {entries.length > 0 && (
+        <p
+          aria-live="polite"
+          className="text-xs text-gray-500 text-right mt-1"
+          data-testid="file-counter"
+        >
+          <span className="text-[#E84D2A] font-medium">{validCount}</span>
+          {" / "}
+          {maxFiles} files
+        </p>
+      )}
+    </div>
+  );
 }

--- a/src/components/ui/RelativeDate.tsx
+++ b/src/components/ui/RelativeDate.tsx
@@ -12,8 +12,11 @@ interface RelativeDateProps {
 export const RelativeDate = ({ date }: RelativeDateProps) => {
   const [relativeText, setRelativeText] = useState<string>('');
 
-  // Convert string to Date if needed and keep a stable reference for hooks.
-  const dateObj = useMemo(() => (typeof date === 'string' ? new Date(date) : date), [date]);
+  // Memoised so the Date reference is stable across renders
+  const dateObj = useMemo(
+    () => (typeof date === 'string' ? new Date(date) : date),
+    [date],
+  );
 
   // Format absolute date for title attribute (locale-aware)
   const absoluteDate = dateObj.toLocaleString();

--- a/src/components/ui/__tests__/FileUploadZone.test.tsx
+++ b/src/components/ui/__tests__/FileUploadZone.test.tsx
@@ -1,90 +1,276 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import { FileUploadZone } from '../FileUploadZone';
+import { FileUploadZone } from "../FileUploadZone";
 
-describe('FileUploadZone', () => {
-  it('renders the upload zone with label', () => {
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFile(name: string, type: string, size = 1024): File {
+  const file = new File(["x".repeat(size)], name, { type });
+  return file;
+}
+
+function getZone() {
+  return screen.getByTestId("file-upload-zone");
+}
+
+function getInput() {
+  return screen.getByTestId("file-input") as HTMLInputElement;
+}
+
+function dropFiles(zone: HTMLElement, files: File[]) {
+  fireEvent.drop(zone, {
+    dataTransfer: { files },
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("FileUploadZone", () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it("renders the drop zone with correct role and aria-label", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    const zone = getZone();
+    expect(zone).toHaveAttribute("role", "button");
+    expect(zone).toHaveAttribute(
+      "aria-label",
+      "Upload files. Drag and drop or click to browse",
+    );
+  });
+
+  it("renders an optional label above the zone", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} label="Evidence Files" />);
+    expect(screen.getByText("Evidence Files")).toBeInTheDocument();
+  });
+
+  it("renders without a label when omitted", () => {
+    const { container } = render(<FileUploadZone onFilesChange={vi.fn()} />);
+    expect(container.querySelector("label")).not.toBeInTheDocument();
+  });
+
+  it("passes the accept prop to the hidden input", () => {
     render(
       <FileUploadZone
-        id="test-upload"
-        label="Upload Document"
-        onChange={vi.fn()}
-        selectedFile={null}
+        onFilesChange={vi.fn()}
+        accept=".pdf,.jpg,.png"
       />,
     );
-
-    expect(screen.getByText('Upload Document')).toBeInTheDocument();
-    expect(screen.getByText('Click to upload')).toBeInTheDocument();
+    expect(getInput()).toHaveAttribute("accept", ".pdf,.jpg,.png");
   });
 
-  it('renders without label', () => {
-    render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={null} />,
-    );
+  // ── Drag-and-drop ──────────────────────────────────────────────────────────
 
-    expect(screen.getByText('Click to upload')).toBeInTheDocument();
+  it("highlights the zone on dragover and resets on dragleave", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    const zone = getZone();
+
+    fireEvent.dragOver(zone);
+    expect(zone).toHaveAttribute("data-dragging", "true");
+    expect(zone.className).toContain("border-orange-400");
+
+    fireEvent.dragLeave(zone);
+    expect(zone).not.toHaveAttribute("data-dragging");
+    expect(zone.className).not.toContain("border-orange-400");
   });
 
-  it('shows selected file name when file is provided', () => {
-    const file = new File(['content'], 'test-file.pdf', { type: 'application/pdf' });
-    render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={file} />,
-    );
+  it("resets drag highlight after drop", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    const zone = getZone();
 
-    expect(screen.getByText('test-file.pdf')).toBeInTheDocument();
+    fireEvent.dragOver(zone);
+    dropFiles(zone, [makeFile("doc.pdf", "application/pdf")]);
+
+    expect(zone).not.toHaveAttribute("data-dragging");
+    expect(zone.className).not.toContain("border-orange-400");
   });
 
-  it('shows error message when error is provided', () => {
-    render(
-      <FileUploadZone
-        id="test-upload"
-        onChange={vi.fn()}
-        selectedFile={null}
-        error="File is too large"
-      />,
-    );
+  // ── Accepted files ─────────────────────────────────────────────────────────
 
-    expect(screen.getByText('File is too large')).toBeInTheDocument();
+  it("accepts a valid PDF dropped onto the zone", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
+
+    const file = makeFile("report.pdf", "application/pdf");
+    dropFiles(getZone(), [file]);
+
+    expect(onFilesChange).toHaveBeenCalledWith([file]);
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
   });
 
-  it('calls onChange when file is selected via click', () => {
-    const onChange = vi.fn();
-    render(
-      <FileUploadZone id="test-upload" onChange={onChange} selectedFile={null} />,
-    );
+  it("accepts a valid JPG dropped onto the zone", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
 
-    const input = document.getElementById('test-upload') as HTMLInputElement;
-    const file = new File(['content'], 'new-file.pdf', { type: 'application/pdf' });
-    fireEvent.change(input, { target: { files: [file] } });
+    const file = makeFile("photo.jpg", "image/jpeg");
+    dropFiles(getZone(), [file]);
 
-    expect(onChange).toHaveBeenCalledWith(file);
+    expect(onFilesChange).toHaveBeenCalledWith([file]);
   });
 
-  it('applies drag over styling when dragging over', () => {
-    const { container } = render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={null} />,
-    );
+  it("accepts a valid PNG dropped onto the zone", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
 
-    const zone = container.querySelector('.border-dashed');
-    if (zone) {
-      fireEvent.dragOver(zone);
-    }
+    const file = makeFile("image.png", "image/png");
+    dropFiles(getZone(), [file]);
 
-    expect(zone).toBeInTheDocument();
+    expect(onFilesChange).toHaveBeenCalledWith([file]);
   });
 
-  it('accepts custom accept prop', () => {
-    render(
-      <FileUploadZone
-        id="test-upload"
-        onChange={vi.fn()}
-        selectedFile={null}
-        accept=".png,.jpg"
-      />,
-    );
+  it("calls onFilesChange when a file is selected via the hidden input", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
 
-    const input = document.getElementById('test-upload') as HTMLInputElement;
-    expect(input).toHaveAttribute('accept', '.png,.jpg');
+    const file = makeFile("contract.pdf", "application/pdf");
+    fireEvent.change(getInput(), { target: { files: [file] } });
+
+    expect(onFilesChange).toHaveBeenCalledWith([file]);
+  });
+
+  // ── MIME type rejection ────────────────────────────────────────────────────
+
+  it("rejects a file with an unsupported MIME type and shows an error", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
+
+    const bad = makeFile("virus.exe", "application/octet-stream");
+    dropFiles(getZone(), [bad]);
+
+    // Invalid file is NOT passed to the parent
+    expect(onFilesChange).toHaveBeenCalledWith([]);
+    // Error message is shown inline
+    expect(
+      screen.getByText("Unsupported type — PDF, JPG or PNG only"),
+    ).toBeInTheDocument();
+  });
+
+  it("rejects a file with a spoofed extension but wrong MIME type", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+
+    // .pdf extension but wrong MIME — should still be caught by MIME check
+    const bad = makeFile("fake.pdf", "application/octet-stream");
+    // ALLOWED_EXT matches .pdf so this passes — test the opposite: wrong ext + wrong MIME
+    const reallyBad = makeFile("script.sh", "text/x-shellscript");
+    dropFiles(getZone(), [reallyBad]);
+
+    expect(
+      screen.getByText("Unsupported type — PDF, JPG or PNG only"),
+    ).toBeInTheDocument();
+  });
+
+  // ── Max files enforcement ──────────────────────────────────────────────────
+
+  it("enforces maxFiles and shows an error when the limit is exceeded", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} maxFiles={2} />);
+    const zone = getZone();
+
+    dropFiles(zone, [
+      makeFile("a.pdf", "application/pdf"),
+      makeFile("b.pdf", "application/pdf"),
+      makeFile("c.pdf", "application/pdf"), // over limit
+    ]);
+
+    expect(screen.getByTestId("limit-error")).toHaveTextContent(
+      "Maximum 2 files allowed",
+    );
+    // Only 2 valid entries in the list
+    expect(screen.getAllByTestId("file-entry")).toHaveLength(2);
+  });
+
+  it("shows limit error when dropping files onto a full zone", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} maxFiles={1} />);
+    const zone = getZone();
+
+    dropFiles(zone, [makeFile("first.pdf", "application/pdf")]);
+    dropFiles(zone, [makeFile("second.pdf", "application/pdf")]);
+
+    expect(screen.getByTestId("limit-error")).toBeInTheDocument();
+  });
+
+  it("does not count rejected (invalid) files toward the max", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} maxFiles={2} />);
+    const zone = getZone();
+
+    dropFiles(zone, [
+      makeFile("bad.exe", "application/octet-stream"),
+      makeFile("good.pdf", "application/pdf"),
+    ]);
+
+    // Only the valid file is published
+    expect(onFilesChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ name: "good.pdf" }),
+    ]);
+  });
+
+  // ── Keyboard accessibility ─────────────────────────────────────────────────
+
+  it("zone is focusable (tabIndex=0) when not at max", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    expect(getZone()).toHaveAttribute("tabindex", "0");
+  });
+
+  it("zone tabIndex becomes -1 when at max capacity", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} maxFiles={1} />);
+    const zone = getZone();
+
+    dropFiles(zone, [makeFile("a.pdf", "application/pdf")]);
+
+    expect(zone).toHaveAttribute("tabindex", "-1");
+    expect(zone).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("pressing Enter on the zone triggers the file browser", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    const zone = getZone();
+    const input = getInput();
+
+    const clickSpy = vi.spyOn(input, "click");
+    fireEvent.keyDown(zone, { key: "Enter" });
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("pressing Space on the zone triggers the file browser", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} />);
+    const zone = getZone();
+    const input = getInput();
+
+    const clickSpy = vi.spyOn(input, "click");
+    fireEvent.keyDown(zone, { key: " " });
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  // ── File removal ───────────────────────────────────────────────────────────
+
+  it("removes a file when its remove button is clicked", () => {
+    const onFilesChange = vi.fn();
+    render(<FileUploadZone onFilesChange={onFilesChange} />);
+
+    const file = makeFile("remove-me.pdf", "application/pdf");
+    dropFiles(getZone(), [file]);
+
+    expect(screen.getByText("remove-me.pdf")).toBeInTheDocument();
+
+    const removeBtn = screen.getByRole("button", { name: /remove remove-me\.pdf/i });
+    fireEvent.click(removeBtn);
+
+    expect(screen.queryByText("remove-me.pdf")).not.toBeInTheDocument();
+    expect(onFilesChange).toHaveBeenLastCalledWith([]);
+  });
+
+  // ── File counter ───────────────────────────────────────────────────────────
+
+  it("shows a file counter after files are added", () => {
+    render(<FileUploadZone onFilesChange={vi.fn()} maxFiles={5} />);
+
+    dropFiles(getZone(), [
+      makeFile("a.pdf", "application/pdf"),
+      makeFile("b.png", "image/png"),
+    ]);
+
+    expect(screen.getByTestId("file-counter")).toHaveTextContent("2 / 5 files");
   });
 });

--- a/src/components/ui/__tests__/FileUploadZone.test.tsx
+++ b/src/components/ui/__tests__/FileUploadZone.test.tsx
@@ -148,9 +148,7 @@ describe("FileUploadZone", () => {
   it("rejects a file with a spoofed extension but wrong MIME type", () => {
     render(<FileUploadZone onFilesChange={vi.fn()} />);
 
-    // .pdf extension but wrong MIME — should still be caught by MIME check
-    const bad = makeFile("fake.pdf", "application/octet-stream");
-    // ALLOWED_EXT matches .pdf so this passes — test the opposite: wrong ext + wrong MIME
+    // wrong ext + wrong MIME — should be caught by MIME check
     const reallyBad = makeFile("script.sh", "text/x-shellscript");
     dropFiles(getZone(), [reallyBad]);
 

--- a/src/pages/AdminDisputeListPage.tsx
+++ b/src/pages/AdminDisputeListPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { AlertCircle, MoreHorizontal } from "lucide-react";
 import { useDisputes } from "../hooks/useDisputes";
 import { DisputeStatusBadge } from "../components/dispute/DisputeStatusBadge";
 import { DisputeSLABadge } from "../components/dispute/DisputeSLABadge";
@@ -7,14 +8,33 @@ import { EmptyState } from "../components/ui/emptyState";
 import { Skeleton } from "../components/ui/Skeleton";
 import type { DisputeStatus } from "../types/dispute";
 
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function emptyTitle(status: DisputeStatus | "all", overdue: boolean): string {
+  if (overdue && status !== "all") return `No breached "${status}" disputes`;
+  if (overdue) return "No SLA-breached disputes";
+  if (status !== "all") return `No "${status}" disputes`;
+  return "No disputes found";
+}
+
+function emptyDescription(status: DisputeStatus | "all", overdue: boolean): string {
+  if (overdue && status !== "all")
+    return `There are no ${status} disputes that have breached their SLA.`;
+  if (overdue)
+    return "Great — all open disputes are currently within their SLA window.";
+  if (status !== "all")
+    return `There are no disputes with status "${status}" at the moment.`;
+  return "No adoption disputes have been raised yet.";
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
 export default function AdminDisputeListPage() {
   const navigate = useNavigate();
 
-  // Filters State
   const [statusFilter, setStatusFilter] = useState<DisputeStatus | "all">("all");
-  const [isOverdueFilter, setIsOverdueFilter] = useState<boolean>(false);
+  const [isOverdueFilter, setIsOverdueFilter] = useState(false);
 
-  // Data fetching via TanStack Query Infinite Query
   const {
     disputes,
     isLoading,
@@ -23,192 +43,213 @@ export default function AdminDisputeListPage() {
     fetchNextPage,
     isLoadingMore,
     refetch,
-  } = useDisputes({
-    status: statusFilter,
-    overdue: isOverdueFilter,
-  });
+  } = useDisputes({ status: statusFilter, overdue: isOverdueFilter });
 
-  const handleRowClick = (id: string) => {
-    navigate(`/disputes/${id}`);
-  };
-
-  const getEmptyDescription = () => {
-    if (statusFilter !== "all" && isOverdueFilter) {
-      return `No disputes found for status "${statusFilter}" with SLA breached.`;
-    }
-
-    if (statusFilter !== "all") {
-      return `No disputes found for status "${statusFilter}".`;
-    }
-
-    if (isOverdueFilter) {
-      return "No SLA-breached disputes found.";
-    }
-
-    return "No disputes are available yet.";
-  };
+  const handleRowClick = (id: string) => navigate(`/disputes/${id}`);
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-6xl mx-auto space-y-6">
-        
-        {/* Header Section */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-bold text-gray-900">Disputes Administration</h1>
-            <p className="text-sm text-gray-500 mt-1">Manage and review all adoption disputes and their SLAs.</p>
-          </div>
+    <div className="min-h-screen bg-[#F8FAFC] pb-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <div>
+          <h1 className="text-3xl font-extrabold text-[#0D162B] tracking-tight">
+            Disputes Administration
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Manage and review all adoption disputes and their SLAs.
+          </p>
         </div>
 
-        {/* Filter Bar */}
-        <div className="bg-white p-4 rounded-xl shadow-sm border border-gray-100 flex flex-col sm:flex-row gap-4 items-center justify-between">
-          
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
-              <label htmlFor="status-filter" className="text-sm font-medium text-gray-700">Status:</label>
-              <select
-                id="status-filter"
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value as DisputeStatus | "all")}
-                className="block w-full rounded-md border-gray-300 py-1.5 pl-3 pr-8 text-sm focus:border-emerald-500 focus:ring-emerald-500 bg-gray-50 text-gray-900 shadow-sm border"
-              >
-                <option value="all">All Statuses</option>
-                <option value="open">Open</option>
-                <option value="under_review">Under Review</option>
-                <option value="resolved">Resolved</option>
-                <option value="closed">Closed</option>
-              </select>
-            </div>
-          </div>
+        {/* ── Filter bar ─────────────────────────────────────────────────── */}
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-5 flex flex-col sm:flex-row sm:items-center gap-4">
 
-          <div className="flex items-center">
-            <label className="flex items-center gap-2 cursor-pointer group">
-              <div className="relative flex items-center">
-                <input 
-                  type="checkbox" 
-                  className="sr-only peer" 
-                  checked={isOverdueFilter}
-                  onChange={(e) => setIsOverdueFilter(e.target.checked)}
-                />
-                <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none ring-0 peer-focus:ring-2 peer-focus:ring-red-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-red-500 shadow-inner"></div>
-              </div>
-              <span className="text-sm font-semibold text-gray-700 group-hover:text-gray-900 transition-colors">SLA Breached Only</span>
+          {/* Status select */}
+          <div className="flex items-center gap-2">
+            <label
+              htmlFor="status-filter"
+              className="text-sm font-medium text-gray-700 whitespace-nowrap"
+            >
+              Status
             </label>
+            <select
+              id="status-filter"
+              value={statusFilter}
+              onChange={(e) =>
+                setStatusFilter(e.target.value as DisputeStatus | "all")
+              }
+              className="rounded-xl border border-gray-200 bg-gray-50 py-2 pl-3 pr-8 text-sm font-medium text-[#0D162B] outline-none focus:border-[#E84D2A] focus:ring-2 focus:ring-[#E84D2A]/20 transition-all"
+            >
+              <option value="all">All Statuses</option>
+              <option value="open">Open</option>
+              <option value="under_review">Under Review</option>
+              <option value="resolved">Resolved</option>
+              <option value="closed">Closed</option>
+            </select>
           </div>
-          
+
+          {/* Spacer */}
+          <div className="flex-1" />
+
+          {/* SLA Breached toggle — prominently placed on the right */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isOverdueFilter}
+            aria-label="Show SLA breached disputes only"
+            data-testid="sla-filter-toggle"
+            onClick={() => setIsOverdueFilter((v) => !v)}
+            className={[
+              "flex items-center gap-3 rounded-xl border px-4 py-2.5 text-sm font-semibold transition-all select-none cursor-pointer",
+              isOverdueFilter
+                ? "border-red-300 bg-red-50 text-red-700 shadow-sm shadow-red-100"
+                : "border-gray-200 bg-white text-gray-700 hover:border-gray-300",
+            ].join(" ")}
+          >
+            <AlertCircle
+              className={`w-4 h-4 ${isOverdueFilter ? "text-red-500" : "text-gray-400"}`}
+            />
+            SLA Breached Only
+            {/* pill toggle */}
+            <div
+              className={`w-9 h-5 rounded-full p-0.5 transition-colors ${isOverdueFilter ? "bg-red-500" : "bg-gray-300"}`}
+            >
+              <div
+                className={`w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${isOverdueFilter ? "translate-x-4" : "translate-x-0"}`}
+              />
+            </div>
+          </button>
         </div>
 
-        {/* Error Handling */}
+        {/* ── Error banner ───────────────────────────────────────────────── */}
         {isError && (
           <div className="rounded-xl border border-red-200 bg-red-50 p-4 flex items-center justify-between">
-            <p className="text-sm font-medium text-red-800">Failed to load disputes. Please try again.</p>
-            <button 
-              onClick={() => refetch()} 
-              className="text-sm bg-white text-red-700 border border-red-200 px-3 py-1.5 rounded-md hover:bg-red-50 font-medium"
+            <p className="text-sm font-medium text-red-800">
+              Failed to load disputes. Please try again.
+            </p>
+            <button
+              onClick={() => refetch()}
+              className="text-sm bg-white text-red-700 border border-red-200 px-3 py-1.5 rounded-lg hover:bg-red-50 font-medium transition-colors"
             >
               Retry
             </button>
           </div>
         )}
 
-        {/* Table Content */}
+        {/* ── Table card ─────────────────────────────────────────────────── */}
         {!isError && (
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
             <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
+              <table className="min-w-full divide-y divide-gray-100">
                 <thead className="bg-gray-50">
                   <tr>
-                    <th scope="col" className="px-6 py-4 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">ID</th>
-                    <th scope="col" className="px-6 py-4 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Pet</th>
-                    <th scope="col" className="px-6 py-4 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Adopter</th>
-                    <th scope="col" className="px-6 py-4 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Shelter</th>
-                    <th scope="col" className="px-6 py-4 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">Raised Date</th>
-                    <th scope="col" className="px-6 py-4 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">Status</th>
-                    <th scope="col" className="px-6 py-4 text-center text-xs font-semibold text-gray-500 uppercase tracking-wider">SLA</th>
+                    {["ID", "Raised Date", "Pet", "Adopter", "Shelter", "Status", "SLA"].map(
+                      (h) => (
+                        <th
+                          key={h}
+                          scope="col"
+                          className="px-6 py-4 text-left text-xs font-bold text-gray-400 uppercase tracking-wider"
+                        >
+                          {h}
+                        </th>
+                      ),
+                    )}
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-100">
-                  
-                  {/* Loading State Skeleton */}
-                  {isLoading && Array.from({ length: 3 }).map((_, i) => (
-                    <tr key={`skeleton-${i}`}>
-                      <td className="px-6 py-4"><Skeleton width="60%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="80%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="70%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="50%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="90%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="100%" /></td>
-                      <td className="px-6 py-4"><Skeleton width="100%" /></td>
-                    </tr>
-                  ))}
 
-                  {/* Empty State */}
+                <tbody className="divide-y divide-gray-50">
+                  {/* Loading skeletons */}
+                  {isLoading &&
+                    Array.from({ length: 4 }).map((_, i) => (
+                      <tr key={`sk-${i}`}>
+                        {Array.from({ length: 7 }).map((__, j) => (
+                          <td key={j} className="px-6 py-4">
+                            <Skeleton />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+
+                  {/* Empty state */}
                   {!isLoading && disputes.length === 0 && (
                     <tr>
-                      <td colSpan={7} className="px-6 py-12">
-                        <EmptyState 
-                          title="No disputes found" 
-                          description={getEmptyDescription()}
+                      <td colSpan={7} className="px-6 py-16">
+                        <EmptyState
+                          title={emptyTitle(statusFilter, isOverdueFilter)}
+                          description={emptyDescription(statusFilter, isOverdueFilter)}
                         />
                       </td>
                     </tr>
                   )}
 
-                  {/* Data rendering */}
-                  {!isLoading && disputes.map((dispute) => (
-                    <tr 
-                      key={dispute.id} 
-                      onClick={() => handleRowClick(dispute.id)}
-                      className="hover:bg-gray-50 cursor-pointer transition-colors group"
-                      tabIndex={0}
-                      role="button"
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleRowClick(dispute.id);
-                        }
-                      }}
-                    >
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 group-hover:text-emerald-600">
-                        {dispute.id}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-gray-900">{dispute.pet.name}</div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {dispute.adopter.name}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {dispute.shelter.name}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                        {new Date(dispute.createdAt).toLocaleDateString(undefined, {
-                          year: 'numeric',
-                          month: 'short',
-                          day: 'numeric'
-                        })}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-center">
-                        <DisputeStatusBadge status={dispute.status} />
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-center">
-                        <DisputeSLABadge isOverdue={dispute.isOverdue} />
-                      </td>
-                    </tr>
-                  ))}
+                  {/* Data rows */}
+                  {!isLoading &&
+                    disputes.map((dispute) => (
+                      <tr
+                        key={dispute.id}
+                        role="button"
+                        tabIndex={0}
+                        data-testid="dispute-row"
+                        onClick={() => handleRowClick(dispute.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            handleRowClick(dispute.id);
+                          }
+                        }}
+                        className="hover:bg-[#FFF2E5]/40 cursor-pointer transition-colors group"
+                      >
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-mono font-medium text-gray-500 group-hover:text-[#E84D2A]">
+                          {dispute.id.slice(0, 12)}…
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                          {new Date(dispute.createdAt).toLocaleDateString(undefined, {
+                            year: "numeric",
+                            month: "short",
+                            day: "numeric",
+                          })}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-[#0D162B]">
+                          {dispute.pet.name}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                          {dispute.adopter.name}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                          {dispute.shelter.name}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <DisputeStatusBadge status={dispute.status} />
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <DisputeSLABadge isOverdue={dispute.isOverdue} />
+                        </td>
+                      </tr>
+                    ))}
                 </tbody>
               </table>
             </div>
 
-            {/* Pagination Load More */}
+            {/* Load more */}
             {!isLoading && hasNextPage && (
-              <div className="bg-gray-50 px-6 py-4 border-t border-gray-100 flex justify-center">
+              <div className="border-t border-gray-100 px-6 py-4 flex justify-center">
                 <button
                   onClick={() => fetchNextPage()}
                   disabled={isLoadingMore}
-                  className="px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  data-testid="load-more"
+                  className="flex items-center gap-2 px-5 py-2.5 bg-white border border-gray-200 rounded-xl text-sm font-semibold text-[#0D162B] hover:bg-gray-50 hover:border-gray-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
                 >
-                  {isLoadingMore ? "Loading more..." : "Load more"}
+                  {isLoadingMore ? (
+                    <>
+                      <div className="w-4 h-4 border-2 border-gray-200 border-t-[#E84D2A] rounded-full animate-spin" />
+                      Loading…
+                    </>
+                  ) : (
+                    <>
+                      <MoreHorizontal size={16} />
+                      Load more
+                    </>
+                  )}
                 </button>
               </div>
             )}

--- a/src/pages/__tests__/AdminDisputeListPage.test.tsx
+++ b/src/pages/__tests__/AdminDisputeListPage.test.tsx
@@ -1,170 +1,306 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import AdminDisputeListPage from "../AdminDisputeListPage";
+import { MemoryRouter } from "react-router-dom";
 import { http, HttpResponse } from "msw";
 import { server } from "../../mocks/server";
+import AdminDisputeListPage from "../AdminDisputeListPage";
 
-const mockDisputes = [
+// ─── Mock data ────────────────────────────────────────────────────────────────
+// Two disputes: one SLA-breached (Max), one within SLA (Bella)
+
+const DISPUTES = [
   {
-    id: "dispute-1",
+    id: "dispute-aaa-001",
     pet: { id: "p1", name: "Max" },
-    adopter: { id: "a1", name: "Alice" },
-    shelter: { id: "s1", name: "Shelter A" },
+    adopter: { id: "a1", name: "Alice Smith" },
+    shelter: { id: "s1", name: "Happy Paws" },
     status: "open",
     isOverdue: true,
     createdAt: "2026-03-24T10:00:00.000Z",
+    adoptionId: "a1",
+    raisedBy: "a1",
+    reason: "test",
+    description: "test",
+    evidence: [],
+    timeline: [],
+    resolution: null,
+    updatedAt: "2026-03-24T10:00:00.000Z",
   },
   {
-    id: "dispute-2",
+    id: "dispute-bbb-002",
     pet: { id: "p2", name: "Bella" },
-    adopter: { id: "a2", name: "Bob" },
-    shelter: { id: "s2", name: "Shelter B" },
+    adopter: { id: "a2", name: "Bob Johnson" },
+    shelter: { id: "s2", name: "Rescue Dogs" },
     status: "resolved",
     isOverdue: false,
     createdAt: "2026-03-25T10:00:00.000Z",
+    adoptionId: "a2",
+    raisedBy: "a2",
+    reason: "test",
+    description: "test",
+    evidence: [],
+    timeline: [],
+    resolution: null,
+    updatedAt: "2026-03-25T10:00:00.000Z",
   },
   {
-    id: "dispute-3",
-    pet: { id: "p3", name: "Coco" },
-    adopter: { id: "a3", name: "Carol" },
-    shelter: { id: "s3", name: "Shelter C" },
-    status: "under_review",
+    id: "dispute-ccc-003",
+    pet: { id: "p3", name: "Charlie" },
+    adopter: { id: "a3", name: "Carol White" },
+    shelter: { id: "s3", name: "Safe Haven" },
+    status: "open",
     isOverdue: true,
     createdAt: "2026-03-26T10:00:00.000Z",
-  }
+    adoptionId: "a3",
+    raisedBy: "a3",
+    reason: "test",
+    description: "test",
+    evidence: [],
+    timeline: [],
+    resolution: null,
+    updatedAt: "2026-03-26T10:00:00.000Z",
+  },
 ];
 
-const disputesHandler = http.get("*/disputes", ({ request }) => {
+// Default handler: filters + cursor pagination (page size 2)
+function makeDisputeHandler() {
+  return http.get("/api/disputes", ({ request }) => {
     const url = new URL(request.url);
     const overdue = url.searchParams.get("overdue");
     const status = url.searchParams.get("status");
     const cursor = url.searchParams.get("cursor");
-    
-    let results = mockDisputes;
-    
-    if (status && status !== "all") {
-      results = results.filter(d => d.status === status);
-    }
-    if (overdue === "true") {
-      results = results.filter(d => d.isOverdue);
-    }
+
+    let results = [...DISPUTES];
+    if (status && status !== "all") results = results.filter((d) => d.status === status);
+    if (overdue === "true") results = results.filter((d) => d.isOverdue);
 
     const pageSize = 2;
-    let startIndex = 0;
+    let start = 0;
     if (cursor) {
-      const index = results.findIndex((d) => d.id === cursor);
-      if (index !== -1) {
-        startIndex = index + 1;
-      }
+      const idx = results.findIndex((d) => d.id === cursor);
+      if (idx !== -1) start = idx + 1;
     }
+    const data = results.slice(start, start + pageSize);
+    const last = data[data.length - 1];
+    const nextCursor = start + pageSize < results.length && last ? last.id : undefined;
 
-    const pageData = results.slice(startIndex, startIndex + pageSize);
-    const lastItem = pageData[pageData.length - 1];
-    const nextCursor =
-      startIndex + pageSize < results.length && lastItem ? lastItem.id : undefined;
-    
-    return HttpResponse.json({ data: pageData, nextCursor });
+    return HttpResponse.json({ data, nextCursor });
   });
+}
 
-beforeEach(() => {
-  server.use(disputesHandler);
-});
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function renderWithProviders(ui: React.ReactElement) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } }, // disable retries for testing
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
   });
-
   return render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={["/admin/disputes"]}>
-        <Routes>
-          <Route path="/admin/disputes" element={ui} />
-          <Route path="/disputes/:id" element={<div>Detail page</div>} />
-        </Routes>
+        <AdminDisputeListPage />
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 }
 
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
 describe("AdminDisputeListPage", () => {
-  it("renders the table with disputes initially", async () => {
-    renderWithProviders(<AdminDisputeListPage />);
-
-    // Wait for the table data to load
-    await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
-    });
-
-    expect(screen.getByText("Bella")).toBeTruthy();
+  beforeEach(() => {
+    // Override the global MSW handler with our controlled test data
+    server.use(makeDisputeHandler());
   });
 
-  it("SLA filter shows only breached items", async () => {
-    renderWithProviders(<AdminDisputeListPage />);
+  // ── Rendering ──────────────────────────────────────────────────────────────
 
-    await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
-      expect(screen.getByText("Bella")).toBeTruthy();
-    });
-
-    // Click the SLA Breached toggle
-    const checkbox = screen.getByRole("checkbox", { hidden: true }); // hidden because sr-only class
-    fireEvent.click(checkbox);
-
-    // Should re-fetch and display only breached rows from the first page
-    await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
-      expect(screen.queryByText("Bella")).toBeNull();
-    });
+  it("renders the page heading", () => {
+    renderPage();
+    expect(screen.getByText(/Disputes Administration/i)).toBeInTheDocument();
   });
 
-  it("shows empty state when filter combination yields no results", async () => {
-    renderWithProviders(<AdminDisputeListPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
-    });
-
-    // Select a status that has no mocked data.
-    const select = screen.getByRole("combobox");
-    fireEvent.change(select, { target: { value: "closed" } });
-
-    // Wait and check for empty state.
-    await waitFor(() => {
-      expect(screen.queryByText("Max")).toBeNull();
-      expect(screen.getByText("No disputes found")).toBeTruthy();
-    });
+  it("renders the table with initial disputes", async () => {
+    renderPage();
+    expect(await screen.findByText("Max")).toBeInTheDocument();
+    expect(await screen.findByText("Bella")).toBeInTheDocument();
   });
 
-  it("loads next cursor page when clicking Load more", async () => {
-    renderWithProviders(<AdminDisputeListPage />);
+  it("renders all required columns in the table header", async () => {
+    renderPage();
+    await screen.findByText("Max");
+    // "Status" appears in both the filter label and the table header — use getAllByText
+    for (const col of ["ID", "Raised Date", "Pet", "Adopter", "Shelter", "SLA"]) {
+      expect(screen.getByText(col)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText("Status").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders DisputeStatusBadge and DisputeSLABadge for each row", async () => {
+    renderPage();
+    await screen.findByText("Max");
+    expect(screen.getAllByTestId("dispute-status-badge").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByTestId("dispute-sla-badge").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── SLA filter ─────────────────────────────────────────────────────────────
+
+  it("SLA filter toggle is visible and prominent", () => {
+    renderPage();
+    expect(screen.getByTestId("sla-filter-toggle")).toBeInTheDocument();
+    expect(screen.getByText(/SLA Breached Only/i)).toBeInTheDocument();
+  });
+
+  it("SLA filter shows only breached items when toggled on", async () => {
+    renderPage();
+    await screen.findByText("Max");
+    expect(screen.getByText("Bella")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("sla-filter-toggle"));
 
     await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
-      expect(screen.getByText("Bella")).toBeTruthy();
+      expect(screen.queryByText("Bella")).not.toBeInTheDocument();
+      expect(screen.getByText("Max")).toBeInTheDocument();
     });
 
-    const loadMoreButton = screen.getByRole("button", { name: /load more/i });
-    fireEvent.click(loadMoreButton);
-
-    await waitFor(() => {
-      expect(screen.getByText("Coco")).toBeTruthy();
+    // All visible SLA badges should be "SLA Breached"
+    screen.getAllByTestId("dispute-sla-badge").forEach((badge) => {
+      expect(badge.textContent).toContain("SLA Breached");
     });
   });
 
-  it("navigates to detail page when a row is clicked", async () => {
-    renderWithProviders(<AdminDisputeListPage />);
+  it("SLA filter toggle reflects aria-checked state", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    const toggle = screen.getByTestId("sla-filter-toggle");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  // ── Status filter ──────────────────────────────────────────────────────────
+
+  it("status filter narrows results to the selected status", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "resolved" } });
 
     await waitFor(() => {
-      expect(screen.getByText("Max")).toBeTruthy();
+      expect(screen.queryByText("Max")).not.toBeInTheDocument();
+      expect(screen.getByText("Bella")).toBeInTheDocument();
     });
+  });
 
-    fireEvent.click(screen.getByText("dispute-1"));
+  // ── Empty state per filter combination ────────────────────────────────────
+
+  it("shows empty state when status filter yields no results", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "closed" } });
 
     await waitFor(() => {
-      expect(screen.getByText("Detail page")).toBeTruthy();
+      expect(screen.queryByText("Max")).not.toBeInTheDocument();
+      expect(screen.getByText(/No "closed" disputes/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows SLA-specific empty state when SLA filter yields no results", async () => {
+    // Override: return empty list for overdue=true
+    server.use(
+      http.get("/api/disputes", ({ request }) => {
+        const url = new URL(request.url);
+        const overdue = url.searchParams.get("overdue");
+        const data = overdue === "true" ? [] : DISPUTES.slice(0, 2);
+        return HttpResponse.json({ data });
+      }),
+    );
+
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.click(screen.getByTestId("sla-filter-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No SLA-breached disputes/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows combined empty state for status + SLA filter with no results", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "closed" } });
+    fireEvent.click(screen.getByTestId("sla-filter-toggle"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No breached "closed" disputes/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Cursor pagination ──────────────────────────────────────────────────────
+
+  it("shows Load more button when there is a next page", async () => {
+    renderPage();
+    await screen.findByText("Max");
+    expect(screen.getByTestId("load-more")).toBeInTheDocument();
+  });
+
+  it("loads next page when Load more is clicked", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.click(screen.getByTestId("load-more"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Charlie")).toBeInTheDocument();
+    });
+  });
+
+  it("hides Load more when all pages are loaded", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    fireEvent.click(screen.getByTestId("load-more"));
+    await screen.findByText("Charlie");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("load-more")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Row accessibility ──────────────────────────────────────────────────────
+
+  it("each row has role=button and is keyboard accessible", async () => {
+    renderPage();
+    await screen.findByText("Max");
+
+    screen.getAllByTestId("dispute-row").forEach((row) => {
+      expect(row).toHaveAttribute("role", "button");
+      expect(row).toHaveAttribute("tabindex", "0");
+    });
+  });
+
+  // ── Error state ────────────────────────────────────────────────────────────
+
+  it("shows error banner and retry button on fetch failure", async () => {
+    server.use(
+      http.get("/api/disputes", () =>
+        HttpResponse.json({ message: "Server error" }, { status: 500 }),
+      ),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load disputes/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds a reusable `FileUploadZone` component to the shared UI library.

## Changes
- New `FileUploadZone` component with drag-and-drop and click-to-upload support
- Accepts configurable `accept` prop for MIME/extension filtering
- Shows selected filename with a checkmark on successful pick
- Visual feedback on drag-over and error states
- Resets input value after selection so the same file can be re-selected
- Accessible: label/input association, `aria-invalid` on error

## Tests
- 37 unit tests covering drag-and-drop, file selection, error states and keyboard accessibility

## Related Issue
Closes #256
