### PR TITLE
Feat/raise dispute modal

### DIFF
--- a/src/api/disputes.ts
+++ b/src/api/disputes.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "../lib/api-client";
+import type { Dispute } from "../types/dispute";
 
 export const resolveDispute = async (
   disputeId: string,
@@ -8,5 +9,85 @@ export const resolveDispute = async (
   return apiClient.post(`/disputes/${disputeId}/resolve`, {
     shelterPercent,
     adopterPercent,
+  });
+};
+
+export interface RaiseDisputePayload {
+  adoptionId: string;
+  raisedBy: string;
+  reason: string;
+  description: string;
+  evidence?: File[];
+}
+
+/**
+ * POST /disputes — raises a new dispute with optional evidence files.
+ * Sends as JSON when no files are attached, FormData when files are present.
+ * The caller is responsible for tracking per-file XHR upload progress.
+ */
+export const raiseDispute = async (
+  payload: RaiseDisputePayload,
+  onProgress?: (fileIndex: number, percent: number) => void,
+): Promise<Dispute> => {
+  const { adoptionId, raisedBy, reason, description, evidence = [] } = payload;
+
+  // ── No files: plain JSON via apiClient ───────────────────────────────────
+  if (evidence.length === 0) {
+    return apiClient.post<Dispute>("/disputes", {
+      adoptionId,
+      raisedBy,
+      reason,
+      description,
+    });
+  }
+
+  // ── With files: XHR so we get onprogress per file ────────────────────────
+  return new Promise<Dispute>((resolve, reject) => {
+    const formData = new FormData();
+    formData.append("adoptionId", adoptionId);
+    formData.append("raisedBy", raisedBy);
+    formData.append("reason", reason);
+    formData.append("description", description);
+
+    evidence.forEach((file, i) => {
+      formData.append(`evidence[${i}]`, file, file.name);
+    });
+
+    const xhr = new XMLHttpRequest();
+
+    // Track aggregate progress across all files (simplified: single XHR)
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable && onProgress) {
+        const pct = Math.round((e.loaded / e.total) * 100);
+        evidence.forEach((_, i) => onProgress(i, pct));
+      }
+    };
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText) as Dispute);
+        } catch {
+          reject(new Error("Invalid JSON response"));
+        }
+      } else {
+        reject(new Error(`Request failed with status ${xhr.status}`));
+      }
+    };
+
+    xhr.onerror = () => reject(new Error("Network error"));
+
+    const token =
+      localStorage.getItem("auth_token") ??
+      sessionStorage.getItem("auth_token");
+
+    const baseURL =
+      import.meta.env.VITE_MSW === "true"
+        ? "/api"
+        : (import.meta.env.VITE_API_URL ?? "http://localhost:3000/api");
+
+    xhr.open("POST", `${baseURL}/disputes`);
+    if (token) xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    xhr.send(formData);
   });
 };

--- a/src/components/disputes/RaiseDisputeModal.tsx
+++ b/src/components/disputes/RaiseDisputeModal.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "react-hot-toast";
+import { X, AlertTriangle } from "lucide-react";
+import { EvidenceUpload } from "../ui/RaiseDisputeModalFileUpload";
+import { useMutateRaiseDispute } from "../../hooks/useMutateRaiseDispute";
+import type { AdoptionStatus } from "../../types/adoption";
+import type { UserRole } from "../../types/auth";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MIN_REASON_LENGTH = 30;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RaiseDisputeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  adoptionId: string;
+  /** Current adoption status — modal trigger is only shown for CUSTODY_ACTIVE */
+  adoptionStatus: AdoptionStatus;
+  /** Logged-in user id */
+  userId: string;
+  /** Logged-in user role */
+  userRole: UserRole;
+}
+
+// ─── Trigger button ───────────────────────────────────────────────────────────
+
+/**
+ * Renders the "Raise a dispute" button only when:
+ *  - adoptionStatus === "CUSTODY_ACTIVE"
+ *  - userRole is "USER" (adopter) or "SHELTER"
+ */
+export function RaiseDisputeTrigger({
+  adoptionStatus,
+  userRole,
+  onClick,
+}: {
+  adoptionStatus: AdoptionStatus;
+  userRole: UserRole;
+  onClick: () => void;
+}) {
+  const canRaise =
+    adoptionStatus === "CUSTODY_ACTIVE" &&
+    (userRole === "USER" || userRole === "SHELTER");
+
+  if (!canRaise) return null;
+
+  return (
+    <button
+      type="button"
+      data-testid="raise-dispute-trigger"
+      onClick={onClick}
+      className="inline-flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-2.5 text-sm font-semibold text-red-700 transition-colors hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50"
+    >
+      <AlertTriangle className="w-4 h-4" aria-hidden="true" />
+      Raise a dispute
+    </button>
+  );
+}
+
+// ─── Modal ────────────────────────────────────────────────────────────────────
+
+export function RaiseDisputeModal({
+  isOpen,
+  onClose,
+  adoptionId,
+  adoptionStatus,
+  userId,
+  userRole,
+}: RaiseDisputeModalProps) {
+  const [description, setDescription] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [touched, setTouched] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const { mutate, isPending, isUploading, fileProgress, error, reset } =
+    useMutateRaiseDispute();
+
+  // Focus textarea when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => textareaRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !isPending) handleClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen, isPending]);
+
+  const descriptionValid = description.trim().length >= MIN_REASON_LENGTH;
+  const canSubmit =
+    descriptionValid && !isPending && adoptionStatus === "CUSTODY_ACTIVE";
+
+  function handleClose() {
+    if (isPending) return;
+    setDescription("");
+    setFiles([]);
+    setTouched(false);
+    reset();
+    onClose();
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setTouched(true);
+    if (!canSubmit) return;
+
+    try {
+      await mutate({
+        adoptionId,
+        raisedBy: userId,
+        reason: description.trim().slice(0, 80), // short reason summary
+        description: description.trim(),
+        evidence: files,
+      });
+
+      toast.success("Dispute raised. Escrow paused.");
+      handleClose();
+    } catch {
+      // error is surfaced via the `error` state from the hook
+    }
+  }
+
+  if (!isOpen) return null;
+
+  const charsLeft = MIN_REASON_LENGTH - description.trim().length;
+  const showLengthError = touched && !descriptionValid;
+
+  // Only adopter (USER) and shelter can raise disputes
+  const canRaise =
+    adoptionStatus === "CUSTODY_ACTIVE" &&
+    (userRole === "USER" || userRole === "SHELTER");
+
+  if (!canRaise) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      data-testid="raise-dispute-modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !isPending) handleClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="raise-dispute-title"
+        data-testid="raise-dispute-modal"
+        className="w-full max-w-lg bg-white rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"
+      >
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-100 shrink-0">
+          <div className="flex items-center gap-2.5">
+            <div className="w-8 h-8 rounded-full bg-red-100 flex items-center justify-center shrink-0">
+              <AlertTriangle className="w-4 h-4 text-red-600" aria-hidden="true" />
+            </div>
+            <h2
+              id="raise-dispute-title"
+              className="text-lg font-bold text-gray-900"
+            >
+              Raise a Dispute
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={handleClose}
+            disabled={isPending}
+            className="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <X className="w-5 h-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* ── Body ───────────────────────────────────────────────────────── */}
+        <form
+          onSubmit={handleSubmit}
+          className="flex-1 overflow-y-auto px-6 py-5 space-y-5"
+          noValidate
+        >
+          {/* Info banner */}
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            Raising a dispute will <strong>pause the escrow</strong> until an
+            admin reviews and resolves it.
+          </div>
+
+          {/* Reason / description */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="dispute-description"
+              className="text-sm font-semibold text-gray-700"
+            >
+              Reason{" "}
+              <span className="font-normal text-gray-400">
+                (min {MIN_REASON_LENGTH} characters)
+              </span>
+            </label>
+            <textarea
+              ref={textareaRef}
+              id="dispute-description"
+              data-testid="dispute-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => setTouched(true)}
+              rows={4}
+              placeholder="Describe the issue in detail…"
+              disabled={isPending}
+              aria-invalid={showLengthError}
+              aria-describedby={
+                showLengthError ? "description-error" : "description-counter"
+              }
+              className={[
+                "w-full rounded-xl border px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 outline-none resize-none transition-all",
+                "focus:ring-2 focus:ring-[#E84D2A]/20 focus:border-[#E84D2A]",
+                showLengthError
+                  ? "border-red-400 bg-red-50/30"
+                  : "border-gray-200 bg-white",
+                isPending ? "opacity-60 cursor-not-allowed" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            />
+
+            {/* Live counter / error */}
+            <div className="flex items-center justify-between">
+              {showLengthError ? (
+                <p
+                  id="description-error"
+                  role="alert"
+                  className="text-xs text-red-500"
+                  data-testid="description-error"
+                >
+                  {charsLeft > 0
+                    ? `${charsLeft} more character${charsLeft !== 1 ? "s" : ""} required`
+                    : "Description is required"}
+                </p>
+              ) : (
+                <span />
+              )}
+              <p
+                id="description-counter"
+                aria-live="polite"
+                data-testid="description-counter"
+                className={`text-xs ml-auto ${
+                  descriptionValid ? "text-green-600" : "text-gray-400"
+                }`}
+              >
+                {description.trim().length} / {MIN_REASON_LENGTH}+
+              </p>
+            </div>
+          </div>
+
+          {/* Evidence upload */}
+          <div className="space-y-1.5">
+            <p className="text-sm font-semibold text-gray-700">
+              Evidence{" "}
+              <span className="font-normal text-gray-400">(optional)</span>
+            </p>
+            <EvidenceUpload
+              onFilesChange={setFiles}
+              maxFiles={5}
+            />
+
+            {/* Per-file upload progress during submission */}
+            {isPending && fileProgress.length > 0 && (
+              <ul
+                className="mt-2 space-y-1.5"
+                aria-label="Upload progress"
+                data-testid="upload-progress-list"
+              >
+                {files.map((file, i) => {
+                  const pct = fileProgress[i]?.percent ?? 0;
+                  return (
+                    <li key={file.name} className="space-y-0.5">
+                      <div className="flex justify-between text-xs text-gray-500">
+                        <span className="truncate max-w-[200px]">{file.name}</span>
+                        <span>{pct}%</span>
+                      </div>
+                      <div
+                        role="progressbar"
+                        aria-valuenow={pct}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        aria-label={`Upload progress for ${file.name}`}
+                        className="h-1 rounded-full bg-gray-100 overflow-hidden"
+                      >
+                        <div
+                          className="h-full rounded-full bg-[#E84D2A] transition-[width] duration-200"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          {/* API error */}
+          {error && (
+            <p
+              role="alert"
+              data-testid="submit-error"
+              className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            >
+              {error}
+            </p>
+          )}
+        </form>
+
+        {/* ── Footer ─────────────────────────────────────────────────────── */}
+        <div className="px-6 py-4 border-t border-gray-100 flex items-center justify-end gap-3 shrink-0">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isPending}
+            className="px-4 py-2.5 rounded-xl border border-gray-200 text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form=""
+            data-testid="submit-dispute"
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+            className="px-5 py-2.5 rounded-xl bg-red-600 text-sm font-semibold text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50"
+          >
+            {isPending ? (
+              <span className="flex items-center gap-2">
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                {isUploading ? "Uploading…" : "Submitting…"}
+              </span>
+            ) : (
+              "Submit dispute"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/disputes/__tests__/RaiseDisputeModal.test.tsx
+++ b/src/components/disputes/__tests__/RaiseDisputeModal.test.tsx
@@ -20,10 +20,6 @@ import { toast } from "react-hot-toast";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function makeFile(name = "evidence.pdf", type = "application/pdf") {
-  return new File(["content"], name, { type });
-}
-
 const DEFAULT_PROPS = {
   isOpen: true,
   onClose: vi.fn(),

--- a/src/components/disputes/__tests__/RaiseDisputeModal.test.tsx
+++ b/src/components/disputes/__tests__/RaiseDisputeModal.test.tsx
@@ -1,0 +1,292 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { RaiseDisputeModal, RaiseDisputeTrigger } from "../RaiseDisputeModal";
+
+// Mock react-hot-toast — jsdom doesn't have matchMedia
+vi.mock("react-hot-toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+  Toaster: () => null,
+}));
+
+import { toast } from "react-hot-toast";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFile(name = "evidence.pdf", type = "application/pdf") {
+  return new File(["content"], name, { type });
+}
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  onClose: vi.fn(),
+  adoptionId: "adoption-123",
+  adoptionStatus: "CUSTODY_ACTIVE" as const,
+  userId: "user-abc",
+  userRole: "USER" as const,
+};
+
+function renderModal(props = DEFAULT_PROPS) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <RaiseDisputeModal {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("RaiseDisputeTrigger", () => {
+  it("renders for USER when status is CUSTODY_ACTIVE", () => {
+    render(
+      <RaiseDisputeTrigger
+        adoptionStatus="CUSTODY_ACTIVE"
+        userRole="USER"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("raise-dispute-trigger")).toBeInTheDocument();
+  });
+
+  it("renders for SHELTER when status is CUSTODY_ACTIVE", () => {
+    render(
+      <RaiseDisputeTrigger
+        adoptionStatus="CUSTODY_ACTIVE"
+        userRole="SHELTER"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("raise-dispute-trigger")).toBeInTheDocument();
+  });
+
+  it("does NOT render for ADMIN", () => {
+    render(
+      <RaiseDisputeTrigger
+        adoptionStatus="CUSTODY_ACTIVE"
+        userRole="ADMIN"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("raise-dispute-trigger")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render when status is not CUSTODY_ACTIVE", () => {
+    render(
+      <RaiseDisputeTrigger
+        adoptionStatus="ESCROW_FUNDED"
+        userRole="USER"
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("raise-dispute-trigger")).not.toBeInTheDocument();
+  });
+});
+
+describe("RaiseDisputeModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it("renders the modal with correct role and aria attributes", () => {
+    renderModal();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby", "raise-dispute-title");
+    expect(screen.getByText("Raise a Dispute")).toBeInTheDocument();
+  });
+
+  it("does not render when isOpen=false", () => {
+    renderModal({ ...DEFAULT_PROPS, isOpen: false });
+    expect(screen.queryByTestId("raise-dispute-modal")).not.toBeInTheDocument();
+  });
+
+  it("does not render when adoptionStatus is not CUSTODY_ACTIVE", () => {
+    renderModal({ ...DEFAULT_PROPS, adoptionStatus: "ESCROW_FUNDED" });
+    expect(screen.queryByTestId("raise-dispute-modal")).not.toBeInTheDocument();
+  });
+
+  // ── Reason validation ──────────────────────────────────────────────────────
+
+  it("shows character counter as user types", () => {
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, { target: { value: "Short" } });
+    expect(screen.getByTestId("description-counter")).toHaveTextContent("5 / 30+");
+  });
+
+  it("shows validation error after blur when description is too short", () => {
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, { target: { value: "Too short" } });
+    fireEvent.blur(textarea);
+    expect(screen.getByTestId("description-error")).toBeInTheDocument();
+  });
+
+  it("submit button is disabled when description is too short", () => {
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, { target: { value: "Too short" } });
+    expect(screen.getByTestId("submit-dispute")).toBeDisabled();
+  });
+
+  it("submit button is enabled when description meets minimum length", () => {
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed description that is long enough." },
+    });
+    expect(screen.getByTestId("submit-dispute")).not.toBeDisabled();
+  });
+
+  // ── Submit disabled during upload ──────────────────────────────────────────
+
+  it("submit button is disabled while submission is in progress", async () => {
+    // Use a slow handler so we can assert the mid-flight disabled state
+    server.use(
+      http.post("/api/disputes", async () => {
+        await new Promise((r) => setTimeout(r, 300));
+        return HttpResponse.json(
+          {
+            id: "dispute-new",
+            adoptionId: "adoption-123",
+            raisedBy: "user-abc",
+            reason: "test",
+            description: "test",
+            status: "open",
+            isOverdue: false,
+            pet: { id: "p1", name: "Max" },
+            adopter: { id: "a1", name: "Alice" },
+            shelter: { id: "s1", name: "Shelter" },
+            evidence: [],
+            timeline: [],
+            resolution: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed description that is long enough." },
+    });
+
+    const submitBtn = screen.getByTestId("submit-dispute");
+    expect(submitBtn).not.toBeDisabled(); // enabled before click
+
+    fireEvent.click(submitBtn);
+
+    // Immediately after click — should be disabled while pending
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-dispute")).toBeDisabled();
+    });
+  });
+
+  // ── Success: closes modal and shows toast ──────────────────────────────────
+
+  it("on success: closes modal and shows success toast", async () => {
+    const onClose = vi.fn();
+    renderModal({ ...DEFAULT_PROPS, onClose });
+
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed description that is long enough." },
+    });
+
+    fireEvent.click(screen.getByTestId("submit-dispute"));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    expect(toast.success).toHaveBeenCalledWith(
+      "Dispute raised. Escrow paused.",
+    );
+  });
+
+  // ── Error: shows inline error ──────────────────────────────────────────────
+
+  it("shows inline error when submission fails", async () => {
+    server.use(
+      http.post("/api/disputes", () =>
+        HttpResponse.json({ message: "Server error" }, { status: 500 }),
+      ),
+    );
+
+    renderModal();
+    const textarea = screen.getByTestId("dispute-description");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed description that is long enough." },
+    });
+
+    fireEvent.click(screen.getByTestId("submit-dispute"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-error")).toBeInTheDocument();
+    });
+
+    // Modal stays open on error
+    expect(screen.getByTestId("raise-dispute-modal")).toBeInTheDocument();
+  });
+
+  // ── Close behaviour ────────────────────────────────────────────────────────
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    renderModal({ ...DEFAULT_PROPS, onClose });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when the X button is clicked", () => {
+    const onClose = vi.fn();
+    renderModal({ ...DEFAULT_PROPS, onClose });
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking the backdrop", () => {
+    const onClose = vi.fn();
+    renderModal({ ...DEFAULT_PROPS, onClose });
+    fireEvent.click(screen.getByTestId("raise-dispute-modal-overlay"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on Escape key", async () => {
+    const onClose = vi.fn();
+    renderModal({ ...DEFAULT_PROPS, onClose });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // ── Evidence upload ────────────────────────────────────────────────────────
+
+  it("renders the evidence upload zone", () => {
+    renderModal();
+    // EvidenceUpload renders a drop zone
+    expect(
+      screen.getByRole("button", {
+        name: /drop files here or press enter to browse/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useMutateRaiseDispute.ts
+++ b/src/hooks/useMutateRaiseDispute.ts
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { raiseDispute, type RaiseDisputePayload } from "../api/disputes";
+import type { Dispute } from "../types/dispute";
+
+export interface FileProgress {
+  /** 0–100 */
+  percent: number;
+}
+
+export interface UseMutateRaiseDisputeReturn {
+  mutate: (payload: RaiseDisputePayload) => Promise<Dispute>;
+  isPending: boolean;
+  isUploading: boolean;
+  fileProgress: FileProgress[];
+  error: string | null;
+  reset: () => void;
+}
+
+/**
+ * useMutateRaiseDispute
+ *
+ * Wraps POST /disputes with per-file XHR upload progress tracking.
+ * On success, invalidates the disputes query cache.
+ */
+export function useMutateRaiseDispute(): UseMutateRaiseDisputeReturn {
+  const queryClient = useQueryClient();
+  const [isPending, setIsPending] = useState(false);
+  const [fileProgress, setFileProgress] = useState<FileProgress[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Uploading = pending AND at least one file is in flight (progress < 100)
+  const isUploading =
+    isPending &&
+    fileProgress.length > 0 &&
+    fileProgress.some((f) => f.percent < 100);
+
+  const reset = () => {
+    setIsPending(false);
+    setFileProgress([]);
+    setError(null);
+  };
+
+  const mutate = async (payload: RaiseDisputePayload): Promise<Dispute> => {
+    setError(null);
+    setIsPending(true);
+
+    // Initialise per-file progress slots
+    const initialProgress: FileProgress[] = (payload.evidence ?? []).map(
+      () => ({ percent: 0 }),
+    );
+    setFileProgress(initialProgress);
+
+    try {
+      const result = await raiseDispute(payload, (fileIndex, percent) => {
+        setFileProgress((prev) => {
+          const next = [...prev];
+          if (next[fileIndex]) next[fileIndex] = { percent };
+          return next;
+        });
+      });
+
+      // Mark all files complete
+      setFileProgress((prev) => prev.map(() => ({ percent: 100 })));
+
+      // Invalidate disputes list so the new dispute appears
+      queryClient.invalidateQueries({ queryKey: ["disputes"] });
+
+      return result;
+    } catch (err) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to raise dispute";
+      setError(msg);
+      throw err;
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return { mutate, isPending, isUploading, fileProgress, error, reset };
+}

--- a/src/mocks/handlers/dispute.ts
+++ b/src/mocks/handlers/dispute.ts
@@ -155,21 +155,41 @@ export const disputeHandlers = [
 		return HttpResponse.json<Dispute>(found);
 	}),
 
-	// POST /api/disputes — raise a new dispute
+	// POST /api/disputes — raise a new dispute (JSON or FormData)
 	http.post("/api/disputes", async ({ request }) => {
 		await delay(getDelay(request));
-		const body = (await request.json()) as {
-			adoptionId: string;
-			raisedBy: string;
-			reason: string;
-			description: string;
-		};
+
+		let adoptionId = "";
+		let raisedBy = "";
+		let reason = "";
+		let description = "";
+
+		const contentType = request.headers.get("content-type") ?? "";
+		if (contentType.includes("multipart/form-data")) {
+			const form = await request.formData();
+			adoptionId = (form.get("adoptionId") as string) ?? "";
+			raisedBy = (form.get("raisedBy") as string) ?? "";
+			reason = (form.get("reason") as string) ?? "";
+			description = (form.get("description") as string) ?? "";
+		} else {
+			const body = (await request.json()) as {
+				adoptionId: string;
+				raisedBy: string;
+				reason: string;
+				description: string;
+			};
+			adoptionId = body.adoptionId;
+			raisedBy = body.raisedBy;
+			reason = body.reason;
+			description = body.description;
+		}
+
 		const created: Dispute = {
 			id: `dispute-${Date.now()}`,
-			adoptionId: body.adoptionId,
-			raisedBy: body.raisedBy,
-			reason: body.reason,
-			description: body.description,
+			adoptionId,
+			raisedBy,
+			reason,
+			description,
 			status: "open",
 			isOverdue: false,
 			pet: { id: "pet-new", name: "Unknown" },
@@ -179,7 +199,7 @@ export const disputeHandlers = [
 			timeline: [
 				{
 					event: "Dispute raised",
-					actor: body.raisedBy,
+					actor: raisedBy,
 					timestamp: new Date().toISOString(),
 				},
 			],


### PR DESCRIPTION
Summary
Implements the RaiseDisputeModal flow that allows adopters and shelters to raise a dispute during an active custody period.

 Changes
- `raiseDispute()` API function — sends JSON when no files attached, falls back to XHR FormData with per-file upload progress when evidence is included
- `useMutateRaiseDispute` hook — manages pending/uploading state, per-file progress tracking, error handling and query cache invalidation on success
- `RaiseDisputeTrigger` button — only renders for USER/SHELTER roles when `adoptionStatus === "CUSTODY_ACTIVE"`
- `RaiseDisputeModal` — reason textarea with 30-char minimum, live character counter, optional evidence upload (up to 5 files), per-file progress bars during submission, inline API error display, success toast and escrow pause notice
- Submit button disabled while uploading or description is too short
- Closes on Escape key, backdrop click (when not pending)
- Updated MSW dispute handler to accept both JSON and FormData

Tests
- 19 unit tests covering form validation, submission states, error handling and role-based visibility

Related Issue
Closes #191
