### PR TITLE
feat: add resolution section to DisputeDetailPage (#195)

### DIFF
--- a/src/components/dispute/DisputeResolutionSection.tsx
+++ b/src/components/dispute/DisputeResolutionSection.tsx
@@ -1,0 +1,148 @@
+import { StatusBadge, type StatusBadgeColor } from "../ui/StatusBadge";
+import { StellarTxLink } from "../ui/StellarTxLink";
+import { SplitOutcomeChart } from "../escrow/SplitOutcomeChart";
+import type { DisputeDetail, ResolutionType } from "../../pages/disputes/types";
+import { stellarExplorerUrl } from "../../lib/stellar";
+
+interface Props {
+  dispute: DisputeDetail;
+}
+
+const RESOLUTION_TYPE_META: Record<
+  ResolutionType,
+  { label: string; color: StatusBadgeColor }
+> = {
+  REFUND: { label: "Refund", color: "blue" },
+  RELEASE: { label: "Release", color: "green" },
+  SPLIT: { label: "Split", color: "amber" },
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function DisputeResolutionSection({ dispute }: Props) {
+  if (dispute.status !== "RESOLVED" || !dispute.resolution) {
+    return null;
+  }
+
+  const { resolution } = dispute;
+  const meta = RESOLUTION_TYPE_META[resolution.type];
+
+  // Build Stellar explorer URL from txHash if present
+  let stellarTxId: string | undefined;
+  try {
+    if (resolution.resolutionTxHash) {
+      stellarExplorerUrl(resolution.resolutionTxHash); // validate
+      stellarTxId = resolution.resolutionTxHash;
+    }
+  } catch {
+    stellarTxId = undefined;
+  }
+
+  return (
+    <section
+      data-testid="dispute-resolution-section"
+      className="bg-white shadow rounded-lg p-6 mt-6"
+      aria-labelledby="resolution-heading"
+    >
+      <h2
+        id="resolution-heading"
+        className="text-lg font-semibold text-gray-900 mb-4"
+      >
+        Resolution
+      </h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Left column */}
+        <div className="space-y-4">
+          {/* Resolution type badge */}
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+              Resolution Type
+            </p>
+            <StatusBadge
+              color={meta.color}
+              label={meta.label}
+              data-testid="resolution-type-badge"
+            />
+          </div>
+
+          {/* Admin note */}
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+              Admin Note
+            </p>
+            <p
+              className="text-sm text-gray-800 bg-gray-50 rounded-md p-3 border border-gray-100"
+              data-testid="resolution-admin-note"
+            >
+              {resolution.adminNote}
+            </p>
+          </div>
+        </div>
+
+        {/* Right column */}
+        <div className="space-y-4">
+          {/* Resolved by */}
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+              Resolved By
+            </p>
+            <p
+              className="text-sm font-medium text-gray-900"
+              data-testid="resolution-resolved-by"
+            >
+              {resolution.resolvedBy}
+            </p>
+          </div>
+
+          {/* Resolved at */}
+          <div>
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+              Resolved At
+            </p>
+            <p
+              className="text-sm text-gray-700"
+              data-testid="resolution-resolved-at"
+            >
+              {formatDate(resolution.resolvedAt)}
+            </p>
+          </div>
+
+          {/* Stellar tx link */}
+          {stellarTxId && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+                Transaction
+              </p>
+              <StellarTxLink
+                id={stellarTxId}
+                type="tx"
+                data-testid="resolution-stellar-tx-link"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* SPLIT: render distribution chart */}
+      {resolution.type === "SPLIT" &&
+        resolution.splitDistribution &&
+        resolution.splitDistribution.length > 0 && (
+          <div className="mt-6" data-testid="resolution-split-chart">
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">
+              Fund Distribution
+            </p>
+            <SplitOutcomeChart distribution={resolution.splitDistribution} />
+          </div>
+        )}
+    </section>
+  );
+}

--- a/src/components/dispute/__tests__/DisputeResolutionSection.test.tsx
+++ b/src/components/dispute/__tests__/DisputeResolutionSection.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DisputeResolutionSection } from "../DisputeResolutionSection";
+import type { DisputeDetail } from "../../../pages/disputes/types";
+
+// Mock stellar lib so tests don't depend on env vars
+vi.mock("../../../lib/stellar", () => ({
+  stellarExplorerUrl: (txHash: string) => {
+    if (!txHash) throw new Error("Transaction hash is required");
+    return `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+  },
+  truncateTxHash: (txHash: string) => {
+    if (!txHash) return "";
+    if (txHash.length <= 16) return txHash;
+    return `${txHash.slice(0, 8)}...${txHash.slice(-8)}`;
+  },
+}));
+
+const baseDispute: DisputeDetail = {
+  id: "DSP-001",
+  raisedBy: { name: "Alice", role: "ADOPTER" },
+  reason: "Pet not as described",
+  status: "OPEN",
+  slaStatus: "ON_TIME",
+  escrow: { status: "LOCKED", accountId: "GBTEST123" },
+  evidence: [],
+  resolution: null,
+};
+
+const resolvedDispute: DisputeDetail = {
+  ...baseDispute,
+  status: "RESOLVED",
+  resolution: {
+    type: "REFUND",
+    adminNote: "Adopter's claim was valid. Full refund issued.",
+    resolvedBy: "Admin Bob",
+    resolvedAt: "2026-04-01T12:00:00Z",
+    resolutionTxHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  },
+};
+
+describe("DisputeResolutionSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when status is OPEN", () => {
+    const { container } = render(
+      <DisputeResolutionSection dispute={baseDispute} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when status is UNDER_REVIEW", () => {
+    const { container } = render(
+      <DisputeResolutionSection
+        dispute={{ ...baseDispute, status: "UNDER_REVIEW" }}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when status is RESOLVED but resolution is null", () => {
+    const { container } = render(
+      <DisputeResolutionSection
+        dispute={{ ...baseDispute, status: "RESOLVED", resolution: null }}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the resolution section when status is RESOLVED", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("dispute-resolution-section")).toBeInTheDocument();
+  });
+
+  it("shows the resolution type badge for REFUND", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("resolution-type-badge")).toBeInTheDocument();
+    expect(screen.getByText("Refund")).toBeInTheDocument();
+  });
+
+  it("shows the resolution type badge for RELEASE", () => {
+    render(
+      <DisputeResolutionSection
+        dispute={{
+          ...resolvedDispute,
+          resolution: { ...resolvedDispute.resolution!, type: "RELEASE" },
+        }}
+      />
+    );
+    expect(screen.getByText("Release")).toBeInTheDocument();
+  });
+
+  it("shows the resolution type badge for SPLIT", () => {
+    render(
+      <DisputeResolutionSection
+        dispute={{
+          ...resolvedDispute,
+          resolution: {
+            ...resolvedDispute.resolution!,
+            type: "SPLIT",
+            splitDistribution: [
+              { recipient: "Shelter", amount: "60.00", percentage: 60 },
+              { recipient: "Adopter", amount: "40.00", percentage: 40 },
+            ],
+          },
+        }}
+      />
+    );
+    expect(screen.getByText("Split")).toBeInTheDocument();
+  });
+
+  it("shows admin note", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("resolution-admin-note")).toHaveTextContent(
+      "Adopter's claim was valid. Full refund issued."
+    );
+  });
+
+  it("shows resolved by", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("resolution-resolved-by")).toHaveTextContent(
+      "Admin Bob"
+    );
+  });
+
+  it("shows resolved at date", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("resolution-resolved-at")).toBeInTheDocument();
+  });
+
+  it("renders StellarTxLink when resolutionTxHash is present", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.getByTestId("stellar-tx-link")).toBeInTheDocument();
+  });
+
+  it("does not render StellarTxLink when resolutionTxHash is absent", () => {
+    render(
+      <DisputeResolutionSection
+        dispute={{
+          ...resolvedDispute,
+          resolution: {
+            ...resolvedDispute.resolution!,
+            resolutionTxHash: undefined,
+          },
+        }}
+      />
+    );
+    expect(screen.queryByTestId("stellar-tx-link")).not.toBeInTheDocument();
+  });
+
+  it("renders SplitOutcomeChart when type is SPLIT with distribution data", () => {
+    render(
+      <DisputeResolutionSection
+        dispute={{
+          ...resolvedDispute,
+          resolution: {
+            type: "SPLIT",
+            adminNote: "Split decision.",
+            resolvedBy: "Admin",
+            resolvedAt: "2026-04-01T12:00:00Z",
+            splitDistribution: [
+              { recipient: "Shelter", amount: "60.00", percentage: 60 },
+              { recipient: "Adopter", amount: "40.00", percentage: 40 },
+            ],
+          },
+        }}
+      />
+    );
+    expect(screen.getByTestId("resolution-split-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("split-outcome-chart")).toBeInTheDocument();
+  });
+
+  it("does not render SplitOutcomeChart when type is REFUND", () => {
+    render(<DisputeResolutionSection dispute={resolvedDispute} />);
+    expect(screen.queryByTestId("resolution-split-chart")).not.toBeInTheDocument();
+  });
+
+  it("does not render SplitOutcomeChart when type is SPLIT but distribution is empty", () => {
+    render(
+      <DisputeResolutionSection
+        dispute={{
+          ...resolvedDispute,
+          resolution: {
+            type: "SPLIT",
+            adminNote: "Split.",
+            resolvedBy: "Admin",
+            resolvedAt: "2026-04-01T12:00:00Z",
+            splitDistribution: [],
+          },
+        }}
+      />
+    );
+    expect(screen.queryByTestId("resolution-split-chart")).not.toBeInTheDocument();
+  });
+});

--- a/src/hooks/useDisputeDetail.ts
+++ b/src/hooks/useDisputeDetail.ts
@@ -1,11 +1,16 @@
 import { useMemo } from "react";
 import { apiClient } from "../lib/api-client";
 import { useApiQuery } from "./useApiQuery";
-import type { DisputeDetail } from "../pages/disputes/types";
+import type { DisputeDetail, DisputeResolution } from "../pages/disputes/types";
 
-interface DisputeDetailApiResponse extends DisputeDetail {
+interface DisputeDetailApiResponse extends Omit<DisputeDetail, "resolution"> {
   resolution?: {
+    type?: string;
+    adminNote?: string;
+    resolvedBy?: string;
+    resolvedAt?: string;
     txHash?: string;
+    splitDistribution?: DisputeResolution["splitDistribution"];
   } | null;
 }
 
@@ -31,11 +36,33 @@ export function useDisputeDetail(disputeId: string) {
       return undefined;
     }
 
+    const raw = query.data;
+
+    // Map API resolution shape to our typed DisputeResolution
+    let resolution: DisputeResolution | null = null;
+    if (
+      raw.resolution &&
+      raw.resolution.type &&
+      (raw.resolution.type === "REFUND" ||
+        raw.resolution.type === "RELEASE" ||
+        raw.resolution.type === "SPLIT")
+    ) {
+      resolution = {
+        type: raw.resolution.type,
+        adminNote: raw.resolution.adminNote ?? "",
+        resolvedBy: raw.resolution.resolvedBy ?? "",
+        resolvedAt: raw.resolution.resolvedAt ?? "",
+        resolutionTxHash: raw.resolution.txHash,
+        splitDistribution: raw.resolution.splitDistribution,
+      };
+    }
+
     return {
-      ...query.data,
-      escrowOnChainStatus: query.data.escrow.status,
-      stellarExplorerUrl: buildStellarExplorerUrl(query.data.escrow.accountId),
-      resolutionTxHash: query.data.resolution?.txHash,
+      ...raw,
+      resolution,
+      escrowOnChainStatus: raw.escrow.status,
+      stellarExplorerUrl: buildStellarExplorerUrl(raw.escrow.accountId),
+      resolutionTxHash: raw.resolution?.txHash,
     };
   }, [query.data]);
 

--- a/src/pages/disputes/DisputeDetailPage.tsx
+++ b/src/pages/disputes/DisputeDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom';
 import { useDisputeDetail } from '../../hooks/useDisputeDetail';
 import { DisputeInfoSection } from '../../components/dispute/DisputeInfoSection';
+import { DisputeResolutionSection } from '../../components/dispute/DisputeResolutionSection';
 import { SkeletonLoader } from '../../components/loaders/SkeletonLoader';
 
 export function DisputeDetailPage() {
@@ -17,7 +18,10 @@ export function DisputeDetailPage() {
             <SkeletonLoader />
           </div>
         ) : data ? (
-          <DisputeInfoSection dispute={data} />
+          <>
+            <DisputeInfoSection dispute={data} />
+            <DisputeResolutionSection dispute={data} />
+          </>
         ) : (
           <div className="bg-red-50 text-red-600 p-4 rounded-md">
             Dispute not found.

--- a/src/pages/disputes/types.ts
+++ b/src/pages/disputes/types.ts
@@ -5,6 +5,23 @@ export interface EvidenceFile {
   sha256: string;
 }
 
+export type ResolutionType = "REFUND" | "RELEASE" | "SPLIT";
+
+export interface ResolutionDistributionItem {
+  recipient: string;
+  amount: string;
+  percentage: number;
+}
+
+export interface DisputeResolution {
+  type: ResolutionType;
+  adminNote: string;
+  resolvedBy: string;
+  resolvedAt: string;
+  resolutionTxHash?: string;
+  splitDistribution?: ResolutionDistributionItem[];
+}
+
 export interface DisputeDetail {
   id: string;
   raisedBy: {
@@ -19,4 +36,5 @@ export interface DisputeDetail {
     accountId: string;
   };
   evidence: EvidenceFile[];
+  resolution?: DisputeResolution | null;
 }


### PR DESCRIPTION
- Extend DisputeDetail type with resolution fields (type, adminNote, resolvedBy, resolvedAt, resolutionTxHash, splitDistribution)
- Add DisputeResolutionSection component that renders only when status === RESOLVED
- Show resolution type badge (REFUND/RELEASE/SPLIT), admin note, resolved by, and resolved at
- Render SplitOutcomeChart with distribution data when type is SPLIT
- Show StellarTxLink for resolutionTxHash using VITE_STELLAR_NETWORK
- Update useDisputeDetail hook to map API resolution shape to typed model
- Wire DisputeResolutionSection into DisputeDetailPage
- Add 15 unit tests covering all required scenarios


closes #195 