### PR TITLE
feat: implement notification preferences update handler and add end-t…

### DIFF
--- a/e2e/notification-preferences.spec.ts
+++ b/e2e/notification-preferences.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Notification preferences flow", () => {
+  test("full preference save flow", async ({ page }) => {
+    await page.goto("/notification-preferences");
+    await expect(
+      page.getByRole("heading", { name: "Notification Preferences" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const label = page.getByText("Escrow Funded");
+    const wrapper = label.locator("..");
+    const track = wrapper.locator("div").first();
+    const inner = track.locator("div").first();
+
+    // Initially should be enabled (translated)
+    const classBefore = await inner.getAttribute("class");
+    expect(classBefore).toContain("translate-x-4");
+
+    // Toggle off and wait for PATCH /api/notifications/preferences
+    await wrapper.click();
+    const req = await page.waitForRequest((r) =>
+      r.url().endsWith("/api/notifications/preferences") && r.method() === "PATCH",
+    );
+
+    const body = JSON.parse(req.postData() || "{}");
+    expect(body.ESCROW_FUNDED).toBe(false);
+    expect(body.APPROVAL_REQUESTED).toBe(true);
+    expect(body.DISPUTE_RAISED).toBe(true);
+    expect(body.SETTLEMENT_COMPLETE).toBe(true);
+    expect(body.DOCUMENT_EXPIRING).toBe(true);
+    expect(body.CUSTODY_EXPIRING).toBe(true);
+
+    await expect(page.getByText("Saved")).toBeVisible();
+    await page.waitForTimeout(100);
+
+    const classAfter = await inner.getAttribute("class");
+    expect(classAfter).not.toContain("translate-x-4");
+
+    // Reload and assert persisted
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Notification Preferences" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const innerAfterReload = page.getByText("Escrow Funded").locator("..").locator("div").first().locator("div").first();
+    const classReload = await innerAfterReload.getAttribute("class");
+    expect(classReload).not.toContain("translate-x-4");
+
+    // Reset to defaults and assert PATCH payload contains all true
+    await page.getByRole("button", { name: "Reset to defaults" }).click();
+    await page.getByRole("button", { name: "Reset" }).click();
+
+    const resetReq = await page.waitForRequest((r) =>
+      r.url().endsWith("/api/notifications/preferences") && r.method() === "PATCH",
+    );
+    const resetBody = JSON.parse(resetReq.postData() || "{}");
+    for (const v of Object.values(resetBody)) {
+      expect(v).toBe(true);
+    }
+
+    await expect(page.getByText("Saved")).toBeVisible();
+    const innerAfterReset = page.getByText("Escrow Funded").locator("..").locator("div").first().locator("div").first();
+    const classAfterReset = await innerAfterReset.getAttribute("class");
+    expect(classAfterReset).toContain("translate-x-4");
+  });
+});

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -115,8 +115,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   }, [state.visible, dismissToast]);
 
   useEffect(() => {
+    const timeoutIds = timeoutIdsRef.current;
+
     return () => {
-      for (const timeoutId of Object.values(timeoutIdsRef.current)) {
+      for (const timeoutId of Object.values(timeoutIds)) {
         clearTimeout(timeoutId);
       }
     };

--- a/src/mocks/handlers/notify.ts
+++ b/src/mocks/handlers/notify.ts
@@ -170,6 +170,15 @@ export const notifyHandlers = [
   // PATCH /api/notifications/preferences - update notification preferences
   http.patch("**/api/notifications/preferences", async ({ request }) => {
     await delay(getDelay(request));
+
+    try {
+      const body = await request.json();
+      // Merge incoming preferences into the mock preferences to simulate persistence
+      mockNotificationPreferences = { ...mockNotificationPreferences, ...(body ?? {}) };
+    } catch (err) {
+      // If parsing fails, continue and return 204 to keep tests resilient
+    }
+
     return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/src/mocks/handlers/notify.ts
+++ b/src/mocks/handlers/notify.ts
@@ -175,7 +175,7 @@ export const notifyHandlers = [
       const body = await request.json();
       // Merge incoming preferences into the mock preferences to simulate persistence
       mockNotificationPreferences = { ...mockNotificationPreferences, ...(body ?? {}) };
-    } catch (err) {
+    } catch {
       // If parsing fails, continue and return 204 to keep tests resilient
     }
 

--- a/src/mocks/handlers/notify.ts
+++ b/src/mocks/handlers/notify.ts
@@ -83,7 +83,7 @@ let mockNotifications: Notification[] = [
   },
 ];
 
-const mockNotificationPreferences: NotificationPreferences = {
+let mockNotificationPreferences: NotificationPreferences = {
   APPROVAL_REQUESTED: true,
   ESCROW_FUNDED: true,
   DISPUTE_RAISED: true,
@@ -172,9 +172,13 @@ export const notifyHandlers = [
     await delay(getDelay(request));
 
     try {
-      const body = await request.json();
-      // Merge incoming preferences into the mock preferences to simulate persistence
-      mockNotificationPreferences = { ...mockNotificationPreferences, ...(body ?? {}) };
+      const body = (await request.json()) as Partial<NotificationPreferences> | null;
+      if (body && typeof body === "object") {
+        mockNotificationPreferences = {
+          ...mockNotificationPreferences,
+          ...body,
+        };
+      }
     } catch {
       // If parsing fails, continue and return 204 to keep tests resilient
     }


### PR DESCRIPTION
closes #237

Description
This PR addresses notification persistence during end-to-end testing by updating the Mock Service Worker (MSW) handler to dynamically update in-memory state. It also introduces a comprehensive E2E test suite to verify the complete user preference configuration flow, including UI toggles, payload verification, state persistence across page reloads, and resetting to defaults.

Changes
🛠️ Mock Service Worker (MSW)
notify.ts: Updated the PATCH /api/notifications/preferences handler to merge incoming payloads into the in-memory mockNotificationPreferences object. This ensures preference updates persist reliably across network requests during active test sessions.

🧪 End-to-End Tests
notification-preferences.spec.ts: Added a new automated test file covering the full notification settings journey:

Verifies toggling off the Escrow Funded notification setting.

Asserts that the PATCH request is intercepted and triggered with the correct payload structure.

Asserts the UI toggle component accurately reflects the disabled state post-save.

Simulates a hard page reload and asserts that the preference states correctly persist.

Verifies the "Reset to defaults" functionality, ensuring all toggles return to their enabled states and dispatch a complete payload.

Verification Results
[ ] Dev tools verified (MSW correctly intercepts and merges states).

[ ] E2E suite passes locally (notification-preferences.spec.ts).