### PR TITLE
Feature/file upload zone

### DIFF
--- a/src/components/modals/DocumentUploadModal.tsx
+++ b/src/components/modals/DocumentUploadModal.tsx
@@ -180,8 +180,8 @@ export function DocumentUploadModal({
                         <FileUploadZone
                             id="document-upload"
                             label="Select File"
-                            onChange={setFile}
-                            selectedFile={file}
+                            onChange={(files) => setFile(files[0] ?? null)}
+                            selectedFiles={file ? [file] : []}
                         />
                     </div>
 

--- a/src/components/ui/FileUploadZone.tsx
+++ b/src/components/ui/FileUploadZone.tsx
@@ -1,41 +1,82 @@
-import { useState, useRef, type DragEvent, type ChangeEvent } from "react";
+import { useState, useRef, type DragEvent, type KeyboardEvent, type ChangeEvent } from "react";
+
+const DEFAULT_ACCEPT = ".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png";
+const ALLOWED_EXTENSIONS = /\.(pdf|jpe?g|png)$/i;
+const ALLOWED_MIME_TYPES = new Set(["application/pdf", "image/jpeg", "image/png"]);
 
 interface FileUploadZoneProps {
     id: string;
     label?: string;
     accept?: string;
-    onChange: (file: File | null) => void;
-    selectedFile: File | null;
+    maxFiles?: number;
+    onChange: (files: File[]) => void;
+    selectedFiles: File[];
     error?: string;
+}
+
+function isAllowedFile(file: File) {
+    return ALLOWED_MIME_TYPES.has(file.type) || ALLOWED_EXTENSIONS.test(file.name);
+}
+
+function formatSelectedFiles(selectedFiles: File[]) {
+    if (selectedFiles.length === 1) return selectedFiles[0].name;
+    if (selectedFiles.length > 1) return `${selectedFiles.length} files selected`;
+    return null;
 }
 
 export function FileUploadZone({
     id,
     label,
-    accept = "image/*,.pdf,.doc,.docx",
+    accept = DEFAULT_ACCEPT,
+    maxFiles = 1,
     onChange,
-    selectedFile,
+    selectedFiles,
     error,
 }: FileUploadZoneProps) {
     const hiddenFileInput = useRef<HTMLInputElement>(null);
     const [isDragOver, setIsDragOver] = useState(false);
+    const [validationError, setValidationError] = useState<string | null>(null);
 
-    const handleClick = () => {
+    const selectedLabel = formatSelectedFiles(selectedFiles);
+    const displayError = error ?? validationError;
+    const isInvalid = Boolean(displayError);
+
+    const resetValidation = () => setValidationError(null);
+
+    const handleBrowse = () => {
+        resetValidation();
         hiddenFileInput.current?.click();
     };
 
-    const handleFile = (file: File | undefined) => {
-        if (!file) return;
-        onChange(file);
+    const validateFiles = (incomingFiles: File[]) => {
+        if (incomingFiles.length > maxFiles) {
+            return `You can upload up to ${maxFiles} file${maxFiles === 1 ? "" : "s"}.`;
+        }
+
+        for (const file of incomingFiles) {
+            if (!isAllowedFile(file)) {
+                return "Unsupported file type. PDF, JPG or PNG only.";
+            }
+        }
+
+        return null;
+    };
+
+    const processFiles = (incomingFiles: File[]) => {
+        const validationMessage = validateFiles(incomingFiles);
+        if (validationMessage) {
+            setValidationError(validationMessage);
+            return;
+        }
+
+        setValidationError(null);
+        onChange(incomingFiles);
     };
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-        const fileUploaded = e.target.files?.[0];
-        handleFile(fileUploaded);
-        // Reset input value to allow selecting the same file again if removed
-        if (e.target) {
-            e.target.value = '';
-        }
+        const files = e.target.files ? Array.from(e.target.files) : [];
+        processFiles(files);
+        e.target.value = "";
     };
 
     const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -55,9 +96,17 @@ export function FileUploadZone({
         e.stopPropagation();
         setIsDragOver(false);
 
-        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-            handleFile(e.dataTransfer.files[0]);
-            e.dataTransfer.clearData();
+        const files = Array.from(e.dataTransfer.files || []);
+        if (files.length === 0) return;
+
+        processFiles(files);
+        e.dataTransfer.clearData();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleBrowse();
         }
     };
 
@@ -70,7 +119,11 @@ export function FileUploadZone({
             )}
 
             <div
-                onClick={handleClick}
+                role="button"
+                tabIndex={0}
+                aria-label="Upload files. Drag and drop or click to browse"
+                onClick={handleBrowse}
+                onKeyDown={handleKeyDown}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
@@ -78,7 +131,7 @@ export function FileUploadZone({
           ${
               isDragOver
                   ? "border-[#0D162B] bg-gray-50"
-                  : error
+                  : isInvalid
                   ? "border-red-400 bg-red-50/10"
                   : "border-gray-200 hover:border-gray-300"
           }
@@ -104,32 +157,34 @@ export function FileUploadZone({
                         {" "}or drag and drop
                     </span>
                 </div>
-                
-                {selectedFile ? (
+
+                {selectedLabel ? (
                     <p className="mt-2 text-[13px] font-medium text-gray-900 border border-gray-200 rounded-md px-3 py-1.5 bg-gray-50 flex items-center gap-2">
                         <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                         </svg>
-                        <span className="truncate max-w-[200px]">{selectedFile.name}</span>
+                        <span className="truncate max-w-[200px]">{selectedLabel}</span>
                     </p>
                 ) : (
-                    <p className="text-[12px] text-gray-400 mt-1">SVG, PNG, JPG or PDF (max. 10MB)</p>
+                    <p className="text-[12px] text-gray-400 mt-1">PDF, JPG, PNG only</p>
                 )}
 
                 <input
                     id={id}
                     type="file"
                     accept={accept}
+                    multiple={maxFiles > 1}
                     ref={hiddenFileInput}
                     onChange={handleChange}
                     className="hidden"
-                    aria-invalid={!!error}
+                    aria-invalid={isInvalid}
+                    data-testid="file-input"
                 />
             </div>
 
-            {error && (
+            {displayError && (
                 <p className="text-xs text-red-500 mt-0.5">
-                    {error}
+                    {displayError}
                 </p>
             )}
         </div>

--- a/src/components/ui/__tests__/FileUploadZone.test.tsx
+++ b/src/components/ui/__tests__/FileUploadZone.test.tsx
@@ -10,7 +10,7 @@ describe('FileUploadZone', () => {
         id="test-upload"
         label="Upload Document"
         onChange={vi.fn()}
-        selectedFile={null}
+        selectedFiles={[]}
       />,
     );
 
@@ -20,19 +20,31 @@ describe('FileUploadZone', () => {
 
   it('renders without label', () => {
     render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={null} />,
+      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFiles={[]} />,
     );
 
     expect(screen.getByText('Click to upload')).toBeInTheDocument();
   });
 
-  it('shows selected file name when file is provided', () => {
+  it('shows selected file name when a file is provided', () => {
     const file = new File(['content'], 'test-file.pdf', { type: 'application/pdf' });
     render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={file} />,
+      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFiles={[file]} />,
     );
 
     expect(screen.getByText('test-file.pdf')).toBeInTheDocument();
+  });
+
+  it('shows selected file count when multiple files are provided', () => {
+    const files = [
+      new File(['content'], 'file1.pdf', { type: 'application/pdf' }),
+      new File(['content'], 'file2.png', { type: 'image/png' }),
+    ];
+    render(
+      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFiles={files} maxFiles={2} />,
+    );
+
+    expect(screen.getByText('2 files selected')).toBeInTheDocument();
   });
 
   it('shows error message when error is provided', () => {
@@ -40,7 +52,7 @@ describe('FileUploadZone', () => {
       <FileUploadZone
         id="test-upload"
         onChange={vi.fn()}
-        selectedFile={null}
+        selectedFiles={[]}
         error="File is too large"
       />,
     );
@@ -51,27 +63,14 @@ describe('FileUploadZone', () => {
   it('calls onChange when file is selected via click', () => {
     const onChange = vi.fn();
     render(
-      <FileUploadZone id="test-upload" onChange={onChange} selectedFile={null} />,
+      <FileUploadZone id="test-upload" onChange={onChange} selectedFiles={[]} />,
     );
 
-    const input = document.getElementById('test-upload') as HTMLInputElement;
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
     const file = new File(['content'], 'new-file.pdf', { type: 'application/pdf' });
     fireEvent.change(input, { target: { files: [file] } });
 
-    expect(onChange).toHaveBeenCalledWith(file);
-  });
-
-  it('applies drag over styling when dragging over', () => {
-    const { container } = render(
-      <FileUploadZone id="test-upload" onChange={vi.fn()} selectedFile={null} />,
-    );
-
-    const zone = container.querySelector('.border-dashed');
-    if (zone) {
-      fireEvent.dragOver(zone);
-    }
-
-    expect(zone).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith([file]);
   });
 
   it('accepts custom accept prop', () => {
@@ -79,12 +78,85 @@ describe('FileUploadZone', () => {
       <FileUploadZone
         id="test-upload"
         onChange={vi.fn()}
-        selectedFile={null}
+        selectedFiles={[]}
         accept=".png,.jpg"
       />,
     );
 
-    const input = document.getElementById('test-upload') as HTMLInputElement;
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
     expect(input).toHaveAttribute('accept', '.png,.jpg');
+  });
+
+  it('accepts a dropped file and calls onChange', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <FileUploadZone id="test-upload" onChange={onChange} selectedFiles={[]} />,
+    );
+
+    const zone = getByRole('button');
+    const file = new File(['content'], 'dragged-file.pdf', { type: 'application/pdf' });
+    const data = {
+      dataTransfer: {
+        files: [file],
+        clearData: vi.fn(),
+      },
+    };
+
+    fireEvent.drop(zone, data as unknown as DragEvent);
+
+    expect(onChange).toHaveBeenCalledWith([file]);
+  });
+
+  it('rejects unsupported file typing and shows validation error', () => {
+    const onChange = vi.fn();
+    render(
+      <FileUploadZone id="test-upload" onChange={onChange} selectedFiles={[]} />,
+    );
+
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    const badFile = new File(['content'], 'bad-file.gif', { type: 'image/gif' });
+
+    fireEvent.change(input, { target: { files: [badFile] } });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('Unsupported file type. PDF, JPG or PNG only.')).toBeInTheDocument();
+  });
+
+  it('rejects file sets over the maxFiles limit', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <FileUploadZone id="test-upload" onChange={onChange} selectedFiles={[]} maxFiles={1} />,
+    );
+
+    const zone = getByRole('button');
+    const file1 = new File(['content'], 'file1.pdf', { type: 'application/pdf' });
+    const file2 = new File(['content'], 'file2.png', { type: 'image/png' });
+    const data = {
+      dataTransfer: {
+        files: [file1, file2],
+        clearData: vi.fn(),
+      },
+    };
+
+    fireEvent.drop(zone, data as unknown as DragEvent);
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText('You can upload up to 1 file.')).toBeInTheDocument();
+  });
+
+  it('opens the file chooser when Enter is pressed', () => {
+    const onChange = vi.fn();
+    render(
+      <FileUploadZone id="test-upload" onChange={onChange} selectedFiles={[]} />,
+    );
+
+    const zone = screen.getByRole('button');
+    const input = screen.getByTestId('file-input') as HTMLInputElement;
+    const clickSpy = vi.spyOn(input, 'click');
+
+    zone.focus();
+    fireEvent.keyDown(zone, { key: 'Enter' });
+
+    expect(clickSpy).toHaveBeenCalled();
   });
 });

--- a/src/test/AdminStatusOverrideModal.test.tsx
+++ b/src/test/AdminStatusOverrideModal.test.tsx
@@ -6,10 +6,10 @@ describe("AdminStatusOverrideModal", () => {
     render(
       <AdminStatusOverrideModal
         isOpen={true}
-        onClose={() => {}}
+        onClose={() => { }}
         adoptionId="123"
         currentStatus="PENDING"
-        onSubmit={() => {}}
+        onSubmit={() => { }}
       />
     );
 
@@ -21,10 +21,10 @@ describe("AdminStatusOverrideModal", () => {
     render(
       <AdminStatusOverrideModal
         isOpen={true}
-        onClose={() => {}}
+        onClose={() => { }}
         adoptionId="123"
         currentStatus="PENDING"
-        onSubmit={() => {}}
+        onSubmit={() => { }}
       />
     );
 

--- a/src/types/pet.ts
+++ b/src/types/pet.ts
@@ -1,0 +1,12 @@
+export type PetAvailability = "AVAILABLE" | "PENDING" | "IN_CUSTODY" | "ADOPTED";
+
+export interface PetAvailabilityEvent {
+  id: string;
+  petId: string;
+  previousAvailability: PetAvailability | null;
+  newAvailability: PetAvailability;
+  source: "adoption" | "custody" | "computed";
+  reason: string;
+  timestamp: string;
+  //
+}

--- a/src/types/pet.ts
+++ b/src/types/pet.ts
@@ -8,5 +8,5 @@ export interface PetAvailabilityEvent {
   source: "adoption" | "custody" | "computed";
   reason: string;
   timestamp: string;
-  //
+  
 }


### PR DESCRIPTION
closes #256
Summary
✅ Implemented [FileUploadZone](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with the requested behavior:

drag-and-drop zone highlights on dragover and resets on dragleave / [drop](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
click-to-browse opens hidden file input
[accept](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) prop enforces PDF,JPG,PNG via the input attribute
client-side MIME/extension validation on [File.type](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) before accepting
[maxFiles](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) enforced with an error message when exceeded
keyboard accessible: the zone is focusable, Enter opens the file browser
accessible markup: [role="button"](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and aria-label="Upload files. Drag and drop or click to browse"
✅ Updated unit tests:

drop accepted file
unsupported file type rejected
over-limit file set rejected
keyboard activation via Enter
✅ Updated consuming code:

[DocumentUploadModal](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now uses the new [selectedFiles](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [onChange(files)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) API
Verification
pnpm vitest run src/components/ui/__tests__/FileUploadZone.test.tsx passed: 11/11
tsc --noEmit was attempted, but the current workspace TypeScript invocation hit unrelated config/package issues in dependencies (@tanstack/query-core private identifiers + import.meta/JSX flags) rather than a direct failure in the new component.