### PR TITLE
feat: implement DocumentExpiryBadge component (#259)

### DIFF
--- a/src/components/ui/DocumentExpiryBadge.tsx
+++ b/src/components/ui/DocumentExpiryBadge.tsx
@@ -1,5 +1,8 @@
+import { StatusBadge } from './StatusBadge';
+
 interface DocumentExpiryBadgeProps {
   expiresAt: string | null;
+  status?: string;
 }
 
 export function DocumentExpiryBadge({ expiresAt }: DocumentExpiryBadgeProps) {
@@ -8,24 +11,34 @@ export function DocumentExpiryBadge({ expiresAt }: DocumentExpiryBadgeProps) {
   const now = new Date();
   const expiry = new Date(expiresAt);
   const msUntilExpiry = expiry.getTime() - now.getTime();
-  const daysUntilExpiry = msUntilExpiry / (1000 * 60 * 60 * 24);
+  const daysUntilExpiry = Math.ceil(msUntilExpiry / (1000 * 60 * 60 * 24));
 
-  const config =
-    daysUntilExpiry < 0
-      ? { label: 'Expired', textClass: 'text-red-700', bgClass: 'bg-red-100' }
-      : daysUntilExpiry <= 30
-        ? { label: 'Expiring soon', textClass: 'text-amber-700', bgClass: 'bg-amber-100' }
-        : {
-            label: `Expires ${expiry.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}`,
-            textClass: 'text-blue-700',
-            bgClass: 'bg-blue-100',
-          };
+  const expiryDateStr = expiry.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
 
-  return (
-    <span
-      className={`rounded-full px-2 py-1 text-xs font-medium ${config.textClass} ${config.bgClass}`}
-    >
-      {config.label}
-    </span>
-  );
+  if (daysUntilExpiry < 0) {
+    return (
+      <StatusBadge
+        color="red"
+        label="Expired — re-upload required"
+        tooltip={`Expired on ${expiryDateStr}`}
+      />
+    );
+  }
+
+  if (daysUntilExpiry <= 7) {
+    const dayLabel = daysUntilExpiry === 1 ? 'day' : 'days';
+    return (
+      <StatusBadge
+        color="amber"
+        label={`Expiring in ${daysUntilExpiry} ${dayLabel}`}
+        tooltip={`Expires on ${expiryDateStr}`}
+      />
+    );
+  }
+
+  return null;
 }

--- a/src/components/ui/__tests__/DocumentExpiryBadge.test.tsx
+++ b/src/components/ui/__tests__/DocumentExpiryBadge.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DocumentExpiryBadge } from '../DocumentExpiryBadge';
+
+describe('DocumentExpiryBadge', () => {
+  it('renders nothing when expiresAt is null', () => {
+    const { container } = render(<DocumentExpiryBadge expiresAt={null} status="APPROVED" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders red badge when document is expired', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const expiresAt = yesterday.toISOString();
+
+    const { container } = render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(screen.getByText('Expired — re-upload required')).toBeTruthy();
+    const badge = container.querySelector('.status-badge--red');
+    expect(badge).toBeTruthy();
+
+    const tooltip = container.querySelector('.status-badge__tooltip');
+    expect(tooltip).toBeTruthy();
+    expect(tooltip?.textContent).toContain('Expired on');
+  });
+
+  it('renders amber badge when expiring in 7 days', () => {
+    const sevenDaysFromNow = new Date();
+    sevenDaysFromNow.setDate(sevenDaysFromNow.getDate() + 7);
+    const expiresAt = sevenDaysFromNow.toISOString();
+
+    const { container } = render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(screen.getByText('Expiring in 7 days')).toBeTruthy();
+    const badge = container.querySelector('.status-badge--amber');
+    expect(badge).toBeTruthy();
+
+    const tooltip = container.querySelector('.status-badge__tooltip');
+    expect(tooltip).toBeTruthy();
+    expect(tooltip?.textContent).toContain('Expires on');
+  });
+
+  it('renders amber badge when expiring in 1 day with singular label', () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const expiresAt = tomorrow.toISOString();
+
+    const { container } = render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(screen.getByText('Expiring in 1 day')).toBeTruthy();
+    const badge = container.querySelector('.status-badge--amber');
+    expect(badge).toBeTruthy();
+  });
+
+  it('renders amber badge when expiring in 3 days', () => {
+    const threeDaysFromNow = new Date();
+    threeDaysFromNow.setDate(threeDaysFromNow.getDate() + 3);
+    const expiresAt = threeDaysFromNow.toISOString();
+
+    render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(screen.getByText('Expiring in 3 days')).toBeTruthy();
+  });
+
+  it('renders nothing when expiring in more than 7 days', () => {
+    const eightDaysFromNow = new Date();
+    eightDaysFromNow.setDate(eightDaysFromNow.getDate() + 8);
+    const expiresAt = eightDaysFromNow.toISOString();
+
+    const { container } = render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when expiring in 30 days', () => {
+    const thirtyDaysFromNow = new Date();
+    thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
+    const expiresAt = thirtyDaysFromNow.toISOString();
+
+    const { container } = render(<DocumentExpiryBadge expiresAt={expiresAt} status="APPROVED" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/ui/__tests__/DocumentRow.test.tsx
+++ b/src/components/ui/__tests__/DocumentRow.test.tsx
@@ -161,11 +161,11 @@ describe('DocumentRow — expiry badge', () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText('Expired')).toBeInTheDocument();
+    expect(screen.getByText('Expired — re-upload required')).toBeInTheDocument();
   });
 
-  it('renders expiring soon badge when expiresAt is within 30 days', () => {
-    const soon = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
+  it('renders expiring soon badge when expiresAt is within 7 days', () => {
+    const soon = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
     render(
       <DocumentRow
         document={{ ...BASE_DOC, expiresAt: soon }}
@@ -174,11 +174,11 @@ describe('DocumentRow — expiry badge', () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText('Expiring soon')).toBeInTheDocument();
+    expect(screen.getByText(/Expiring in \d+ days?/)).toBeInTheDocument();
   });
 
-  it('renders expiry date badge when expiresAt is beyond 30 days', () => {
-    const future = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString();
+  it('renders no expiry badge when expiresAt is beyond 7 days', () => {
+    const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
     render(
       <DocumentRow
         document={{ ...BASE_DOC, expiresAt: future }}
@@ -187,7 +187,7 @@ describe('DocumentRow — expiry badge', () => {
         onDelete={vi.fn()}
       />,
     );
-    expect(screen.getByText(/Expires/)).toBeInTheDocument();
+    expect(screen.queryByText(/Expir/)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
- Accept expiresAt and status props (status optional)
- Return null when expiresAt is null
- Show amber badge 'Expiring in X days' when within 7 days
- Show red badge 'Expired — re-upload required' when past expiry
- Include tooltip with exact expiry date
- Add comprehensive unit tests covering all scenarios
- Update DocumentRow tests to match new behavior
close #259