### PR TITLE
feat(escrow): dismissible EscrowFundedBanner with slide-in animation

### DIFF
--- a/src/components/escrow/EscrowFundedBanner.tsx
+++ b/src/components/escrow/EscrowFundedBanner.tsx
@@ -1,49 +1,92 @@
 import { useState } from "react";
+import { CheckCircle2 } from "lucide-react";
+import { StellarTxLink } from "../ui/StellarTxLink";
 import { formatAmount, getEscrowFundedBannerStorageKey } from "./types";
 
 interface EscrowFundedBannerProps {
-  escrowId: string;
+  /** Unique adoption identifier — used as the sessionStorage dismissal key. */
+  adoptionId?: string;
+  /** Displayed name of the pet involved in the adoption. */
+  petName?: string;
+  /** Funded escrow amount. */
   amount: number;
+  /** Optional currency label (defaults to "USDC"). */
   currency?: string;
+  /** Stellar transaction hash for the funding transaction. */
+  txHash?: string;
+  /**
+   * Legacy escrowId — still accepted for backward-compat with callers
+   * (e.g. SettlementSummaryPage and EscrowComponents.test.tsx) that only
+   * pass escrowId/amount/currency.  When adoptionId is omitted, the
+   * escrowId value is used as the sessionStorage key.
+   */
+  escrowId?: string;
 }
 
 export function EscrowFundedBanner({
-  escrowId,
+  adoptionId,
+  petName = "",
   amount,
   currency,
+  txHash,
+  escrowId,
 }: EscrowFundedBannerProps) {
-  const storageKey = getEscrowFundedBannerStorageKey(escrowId);
-  const [dismissed, setDismissed] = useState(
-    () => sessionStorage.getItem(storageKey) === "true",
-  );
+  // Prefer the dedicated adoptionId key; fall back to the legacy escrowId key.
+  const adoptionKey = adoptionId
+    ? `escrow-banner-dismissed-${adoptionId}`
+    : null;
+  const legacyKey = escrowId ? getEscrowFundedBannerStorageKey(escrowId) : null;
+  // At least one key must exist for dismissal to work.
+  const primaryKey = adoptionKey ?? legacyKey ?? "";
 
-  if (dismissed) {
-    return null;
-  }
+  const [dismissed, setDismissed] = useState(() => {
+    if (adoptionKey && sessionStorage.getItem(adoptionKey) === "true") return true;
+    if (legacyKey && sessionStorage.getItem(legacyKey) === "true") return true;
+    return false;
+  });
+
+  if (dismissed) return null;
 
   function dismiss() {
-    sessionStorage.setItem(storageKey, "true");
+    if (primaryKey) sessionStorage.setItem(primaryKey, "true");
+    // Keep the legacy key in sync so existing tests continue to pass.
+    if (legacyKey && legacyKey !== primaryKey) {
+      sessionStorage.setItem(legacyKey, "true");
+    }
     setDismissed(true);
   }
 
   return (
     <div
-      className="flex items-start justify-between gap-4 rounded-3xl border border-emerald-200 bg-emerald-50 p-5 text-emerald-950"
+      role="alert"
+      aria-live="polite"
       data-testid="escrow-funded-banner"
+      className="animate-banner-slide-in flex items-start justify-between gap-4 rounded-3xl border border-emerald-200 bg-emerald-50 p-5 text-emerald-950"
     >
-      <div>
-        <p className="text-sm font-semibold uppercase tracking-[0.2em]">
-          Escrow funded
-        </p>
-        <p className="mt-2 text-lg font-semibold">
-          {formatAmount(amount, currency)} is secured and ready for settlement.
-        </p>
+      <div className="flex items-start gap-3">
+        <CheckCircle2
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 text-emerald-500"
+          size={18}
+        />
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700">
+            Escrow funded
+          </p>
+          <p className="mt-1 text-base font-semibold">
+            Escrow of {formatAmount(amount, currency)} funded
+            {petName ? ` for ${petName}’s adoption` : ""}.{txHash && (
+              <>{" "}<StellarTxLink id={txHash} type="tx" className="text-emerald-700 hover:text-emerald-900" /></>
+            )}
+          </p>
+        </div>
       </div>
+
       <button
-        aria-label="Dismiss funded banner"
-        className="rounded-full border border-emerald-300 px-3 py-1 text-sm font-semibold"
-        onClick={dismiss}
         type="button"
+        aria-label="Dismiss funded banner"
+        onClick={dismiss}
+        className="shrink-0 rounded-full border border-emerald-300 px-3 py-1 text-sm font-semibold hover:bg-emerald-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
       >
         Dismiss
       </button>

--- a/src/components/escrow/__tests__/EscrowFundedBanner.test.tsx
+++ b/src/components/escrow/__tests__/EscrowFundedBanner.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EscrowFundedBanner } from "../EscrowFundedBanner";
+
+// ── Mock StellarTxLink so tests are isolated from its internals ───────────────
+vi.mock("../../ui/StellarTxLink", () => ({
+  StellarTxLink: ({ id }: { id: string }) => (
+    <a href={`https://stellar.expert/explorer/public/tx/${id}`} data-testid="stellar-tx-link">
+      {id}
+    </a>
+  ),
+}));
+
+// ── Shared test data ──────────────────────────────────────────────────────────
+const DEFAULT_PROPS = {
+  adoptionId: "adoption-42",
+  petName: "Luna",
+  amount: 250,
+  currency: "USDC",
+  txHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+};
+
+function renderBanner(props = DEFAULT_PROPS) {
+  return render(<EscrowFundedBanner {...props} />);
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+describe("EscrowFundedBanner", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  // 1. Banner renders with correct petName, amount, and txHash passed to StellarTxLink
+  it("renders with correct petName, amount, and StellarTxLink txHash", () => {
+    renderBanner();
+
+    // petName visible in the message
+    expect(screen.getByText(/Luna/)).toBeInTheDocument();
+    // formatted amount visible
+    expect(screen.getByText(/USDC 250\.00/)).toBeInTheDocument();
+    // StellarTxLink received the txHash
+    expect(screen.getByTestId("stellar-tx-link")).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/public/tx/${DEFAULT_PROPS.txHash}`,
+    );
+  });
+
+  // 2. Clicking dismiss hides the banner
+  it("hides the banner after clicking dismiss", () => {
+    renderBanner();
+
+    expect(screen.getByTestId("escrow-funded-banner")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss funded banner" }));
+
+    expect(screen.queryByTestId("escrow-funded-banner")).toBeNull();
+  });
+
+  // 3. Clicking dismiss sets the correct sessionStorage key for the adoptionId
+  it("sets the correct sessionStorage key on dismiss", () => {
+    renderBanner();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss funded banner" }));
+
+    expect(
+      sessionStorage.getItem(`escrow-banner-dismissed-${DEFAULT_PROPS.adoptionId}`),
+    ).toBe("true");
+  });
+
+  // 4. Re-rendering with a new adoptionId shows the banner even if a different adoptionId was dismissed
+  it("shows the banner for a new adoptionId even when the previous one was dismissed", () => {
+    // Dismiss for the first adoptionId
+    sessionStorage.setItem(`escrow-banner-dismissed-adoption-42`, "true");
+
+    // Render with a fresh adoptionId — banner must appear
+    render(
+      <EscrowFundedBanner
+        {...DEFAULT_PROPS}
+        adoptionId="adoption-99"
+      />,
+    );
+
+    expect(screen.getByTestId("escrow-funded-banner")).toBeInTheDocument();
+  });
+
+  // 5. Banner does not render if sessionStorage already has the dismissal key
+  it("does not render when sessionStorage already has the dismissal key for the current adoptionId", () => {
+    sessionStorage.setItem(
+      `escrow-banner-dismissed-${DEFAULT_PROPS.adoptionId}`,
+      "true",
+    );
+
+    renderBanner();
+
+    expect(screen.queryByTestId("escrow-funded-banner")).toBeNull();
+  });
+
+  // Accessibility: role and aria-live attributes are present
+  it("has role=alert and aria-live=polite on the root element", () => {
+    renderBanner();
+
+    const banner = screen.getByTestId("escrow-funded-banner");
+    expect(banner).toHaveAttribute("role", "alert");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,12 @@
     54% { transform: rotate(-8deg); }
     72% { transform: rotate(5deg); }
   }
+
+  --animate-banner-slide-in: banner-slide-in 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+  @keyframes banner-slide-in {
+    0%   { transform: translateY(-100%); opacity: 0; }
+    100% { transform: translateY(0);     opacity: 1; }
+  }
 }
 
 
@@ -142,6 +148,10 @@
     background-image: linear-gradient(90deg, rgba(255, 255, 255, 0) 0, rgba(255, 255, 255, 0.2) 20%, rgba(255, 255, 255, 0.5) 60%, rgba(255, 255, 255, 0));
     background-size: 200% 100%;
     animation: shimmer 1.5s infinite linear;
+  }
+
+  .animate-banner-slide-in {
+    animation: var(--animate-banner-slide-in);
   }
   .scrollbar-minimal::-webkit-scrollbar-thumb:hover {
     background: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
- Add petName, txHash, adoptionId props; keep escrowId for backward compat
- Render StellarTxLink inline in banner message (type=tx)
- Slide-in via banner-slide-in keyframe in @theme / @layer utilities, matching the existing shimmer/notification-bell animation pattern
- sessionStorage keyed by adoptionId; legacy escrowId key written in sync
- role=alert + aria-live=polite on root; dismiss button has aria-label
- 6 unit tests: render, dismiss, storage key, adoptionId isolation, pre-dismissed suppression, accessibility attributes

closes #124 