### PR TITLE
feat: implement password reset request and reset password screens

### DIFF
--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -1,4 +1,10 @@
 import { apiClient } from "../lib/api-client";
+import type {
+  PasswordResetRequestPayload,
+  PasswordResetPayload,
+  PasswordResetRequestResponse,
+  PasswordResetResponse,
+} from "../types/auth";
 
 export interface RegisterPayload {
   email: string;
@@ -29,5 +35,23 @@ export const authService = {
 
   async login(payload: LoginPayload): Promise<AuthResponse> {
     return apiClient.post<AuthResponse>("/auth/login", payload);
+  },
+
+  async requestPasswordReset(
+    payload: PasswordResetRequestPayload,
+  ): Promise<PasswordResetRequestResponse> {
+    return apiClient.post<PasswordResetRequestResponse>(
+      "/auth/request-password-reset",
+      payload,
+    );
+  },
+
+  async resetPassword(
+    payload: PasswordResetPayload,
+  ): Promise<PasswordResetResponse> {
+    return apiClient.post<PasswordResetResponse>(
+      "/auth/reset-password",
+      payload,
+    );
   },
 };

--- a/src/components/auth/forgetPasswordForm.tsx
+++ b/src/components/auth/forgetPasswordForm.tsx
@@ -1,31 +1,32 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { FormInput } from "../ui/formInput";
 import { SubmitButton } from "../ui/submitButton";
+import { authService } from "../../api/authService";
+import { ApiError } from "../../lib/api-errors";
 
+// ─── ForgetPasswordForm ──────────────────────────────────────────────────────
 
-
-// ─── RegisterForm ─────────────────────────────────────────────────────────────
-
-interface ForgetPasswordFormData {
+interface ForgotPasswordFormData {
   email: string;
 }
 
-interface ForgetPasswordFormErrors {
+interface ForgotPasswordFormErrors {
   email?: string;
+  submit?: string;
 }
 
 export function ForgetPasswordForm() {
-  const [formData, setFormData] = useState<ForgetPasswordFormData>({
-    email: ""
+  const [formData, setFormData] = useState<ForgotPasswordFormData>({
+    email: "",
   });
 
-  const [errors, setErrors] = useState<ForgetPasswordFormErrors>({});
+  const [errors, setErrors] = useState<ForgotPasswordFormErrors>({});
   const [isLoading, setIsLoading] = useState(false);
-  const navigate = useNavigate();
+  const [emailSent, setEmailSent] = useState(false);
 
   const validate = (): boolean => {
-    const newErrors: ForgetPasswordFormErrors = {};
+    const newErrors: ForgotPasswordFormErrors = {};
 
     if (!formData.email.trim()) {
       newErrors.email = "Email address is required";
@@ -37,10 +38,13 @@ export function ForgetPasswordForm() {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleChange = (field: keyof ForgetPasswordFormData, value: string) => {
+  const handleChange = (field: keyof ForgotPasswordFormData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field as keyof ForgetPasswordFormErrors]) {
+    if (errors[field as keyof ForgotPasswordFormErrors]) {
       setErrors((prev) => ({ ...prev, [field]: undefined }));
+    }
+    if (errors.submit) {
+      setErrors((prev) => ({ ...prev, submit: undefined }));
     }
   };
 
@@ -49,19 +53,84 @@ export function ForgetPasswordForm() {
     if (!validate()) return;
 
     setIsLoading(true);
-    // Simulate API call
-    await new Promise((r) => setTimeout(r, 1000));
-    setIsLoading(false);
-
-    // Navigate to reset password page since everything is mock right now
-    navigate("/reset");
+    try {
+      await authService.requestPasswordReset({
+        email: formData.email.trim(),
+      });
+      setEmailSent(true);
+    } catch (err: unknown) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+          ? err.message
+          : "Failed to send reset link. Please try again.";
+      setErrors((prev) => ({ ...prev, submit: message }));
+    } finally {
+      setIsLoading(false);
+    }
   };
 
+  // ── Email-sent confirmation ────────────────────────────────────────────────
+  if (emailSent) {
+    return (
+      <div className="w-full text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+          <svg
+            className="h-8 w-8 text-green-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-900 mb-3">
+          Check Your Email
+        </h2>
+        <p className="text-gray-600 text-sm mb-6 max-w-xs mx-auto">
+          We&apos;ve sent a password reset link to{" "}
+          <span className="font-semibold text-gray-900">{formData.email}</span>.
+          Please check your inbox and follow the instructions.
+        </p>
+
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => setEmailSent(false)}
+            className="w-full rounded-xl border border-gray-200 py-3.5 text-sm font-semibold text-gray-700 transition-all hover:bg-gray-50 active:scale-[0.98]"
+          >
+            Didn&apos;t receive it? Try again
+          </button>
+
+          <Link
+            to="/login"
+            className="w-full rounded-xl bg-[#E84D2A] py-3.5 text-sm font-semibold text-white transition-all hover:bg-[#d4431f] active:scale-[0.98] text-center"
+          >
+            Back to Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Request form ───────────────────────────────────────────────────────────
   return (
     <div className="w-full">
       <h2 className="text-2xl font-bold text-gray-900 text-center mb-6">
-        Forget Password?
+        Forgot Password?
       </h2>
+
+      <p className="text-sm text-gray-500 text-center mb-6">
+        Enter the email address associated with your account and we&apos;ll send
+        you a link to reset your password.
+      </p>
 
       <div className="flex flex-col gap-5">
         <form
@@ -69,6 +138,12 @@ export function ForgetPasswordForm() {
           noValidate
           className="flex flex-col gap-4"
         >
+          {errors.submit && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">
+              {errors.submit}
+            </div>
+          )}
+
           <FormInput
             id="email"
             label="Email Address"
@@ -80,17 +155,21 @@ export function ForgetPasswordForm() {
             error={errors.email}
           />
 
-          <SubmitButton label="Send Me Reset Link" isLoading={isLoading} loadingLabel="Sending reset link..." />
+          <SubmitButton
+            label="Send Reset Link"
+            isLoading={isLoading}
+            loadingLabel="Sending reset link..."
+          />
         </form>
 
         <p className="text-center text-sm text-gray-600">
-          Remember password?{" "}
-          <a
-            href="/login"
+          Remember your password?{" "}
+          <Link
+            to="/login"
             className="font-semibold text-[#E84D2A] hover:underline"
           >
             Sign In
-          </a>
+          </Link>
         </p>
       </div>
     </div>

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,6 +1,8 @@
 export { AuthLayout } from './AuthLayout';
 export { RegisterForm, FormInput, PasswordInput, GoogleButton, OrDivider, SubmitButton } from './RegisterForm';
 export { SignInForm } from './SignInForm';
+export { ForgetPasswordForm } from './forgetPasswordForm';
+export { ResetPasswordForm } from './resetPasswordForm';
 export { ProtectedRoute } from './ProtectedRoute';
 export { GuestRoute } from './GuestRoute';
 export { PublicRoute } from './PublicRoute';

--- a/src/components/auth/resetPasswordForm.tsx
+++ b/src/components/auth/resetPasswordForm.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { SubmitButton } from "../ui/submitButton";
 import { AuthModal } from "../ui/authModal";
+import { authService } from "../../api/authService";
+import { ApiError } from "../../lib/api-errors";
 
 // ─── Reusable: PasswordInput ──────────────────────────────────────────────────
 
@@ -120,9 +122,14 @@ interface ResetPasswordFormData {
 interface ResetPasswordFormErrors {
   password?: string;
   confirmPassword?: string;
+  submit?: string;
+  token?: string;
 }
 
 export function ResetPasswordForm() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+
   const [formData, setFormData] = useState<ResetPasswordFormData>({
     password: "",
     confirmPassword: "",
@@ -136,6 +143,10 @@ export function ResetPasswordForm() {
   const validate = (): boolean => {
     const newErrors: ResetPasswordFormErrors = {};
 
+    if (!token) {
+      newErrors.token = "Reset token is missing or invalid. Please request a new password reset link.";
+    }
+
     if (!formData.password) {
       newErrors.password = "Password is required";
     } else if (formData.password.length < 8) {
@@ -143,7 +154,7 @@ export function ResetPasswordForm() {
     }
 
     if (!formData.confirmPassword) {
-      newErrors.confirmPassword = "Confirm Password is required";
+      newErrors.confirmPassword = "Confirm password is required";
     } else if (formData.confirmPassword !== formData.password) {
       newErrors.confirmPassword = "Passwords do not match";
     }
@@ -163,30 +174,95 @@ export function ResetPasswordForm() {
     e.preventDefault();
     if (!validate()) return;
     setIsLoading(true);
-    // TODO: wire to API
-    await new Promise((r) => setTimeout(r, 1500));
-    setIsLoading(false);
-
-    // Show success modal instead of direct navigation
-    setShowSuccessModal(true);
+    try {
+      await authService.resetPassword({
+        token: token!,
+        password: formData.password,
+      });
+      setShowSuccessModal(true);
+    } catch (err: unknown) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+          ? err.message
+          : "Failed to reset password. Please try again.";
+      setErrors((prev) => ({ ...prev, submit: message }));
+    } finally {
+      setIsLoading(false);
+    }
   };
+
+  // ── Invalid / missing token state ──────────────────────────────────────────
+  if (!token) {
+    return (
+      <div className="w-full text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
+          <svg
+            className="h-8 w-8 text-red-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126z"
+            />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 15.75h.007v.008H12v-.008z"
+            />
+          </svg>
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-900 mb-3">
+          Invalid Reset Link
+        </h2>
+        <p className="text-gray-600 text-sm mb-6 max-w-xs mx-auto">
+          This password reset link is invalid or has expired. Please request a
+          new one.
+        </p>
+
+        <Link
+          to="/forgot-password"
+          className="inline-block w-full rounded-xl bg-[#E84D2A] py-3.5 text-sm font-semibold text-white transition-all hover:bg-[#d4431f] active:scale-[0.98] text-center"
+        >
+          Request New Reset Link
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
       <h2 className="text-2xl font-bold text-gray-900 text-center mb-6">
-        Reset Password?
+        Reset Password
       </h2>
-      <div className="flex flex-col gap-5">
 
+      <p className="text-sm text-gray-500 text-center mb-6">
+        Enter your new password below. Make sure it&apos;s at least 8
+        characters long.
+      </p>
+
+      <div className="flex flex-col gap-5">
         <form
           onSubmit={handleSubmit}
           noValidate
           className="flex flex-col gap-4"
         >
+          {errors.submit && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-600">
+              {errors.submit}
+            </div>
+          )}
+
           <PasswordInput
             id="password"
-            label="Enter Password"
-            placeholder="Enter your password"
+            label="New Password"
+            placeholder="Enter your new password"
             value={formData.password}
             onChange={(value) => handleChange("password", value)}
             error={errors.password}
@@ -194,22 +270,26 @@ export function ResetPasswordForm() {
 
           <PasswordInput
             id="confirmPassword"
-            label="Confirm Password"
-            placeholder="Confirm your password"
+            label="Confirm New Password"
+            placeholder="Confirm your new password"
             value={formData.confirmPassword}
             onChange={(value) => handleChange("confirmPassword", value)}
             error={errors.confirmPassword}
           />
 
-          <SubmitButton label="Save New Password" isLoading={isLoading} loadingLabel="Saving New Password ..." />
+          <SubmitButton
+            label="Reset Password"
+            isLoading={isLoading}
+            loadingLabel="Resetting password..."
+          />
         </form>
       </div>
 
       <AuthModal
         isOpen={showSuccessModal}
         title="Password Updated!"
-        description="You have successfully updated your password"
-        buttonText="Proceed To Sign In"
+        description="Your password has been successfully reset. You can now sign in with your new password."
+        buttonText="Sign In"
         onAction={() => navigate("/login")}
       />
     </div>

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -3,6 +3,9 @@ import { http, HttpResponse, delay } from "msw";
 // In-memory store of registered users for the mock
 const registeredUsers: { email: string; fullName: string; nin: string; password: string; id: string }[] = [];
 
+// Store for password reset tokens (maps token -> email)
+const resetTokens: Map<string, string> = new Map();
+
 export const authHandlers = [
   // POST /api/auth/register
   http.post("/api/auth/register", async ({ request }) => {
@@ -76,6 +79,69 @@ export const authHandlers = [
         fullName: user.fullName,
         role: "USER",
       },
+    });
+  }),
+
+  // POST /api/auth/request-password-reset
+  http.post("/api/auth/request-password-reset", async ({ request }) => {
+    await delay(600);
+
+    const body = (await request.json()) as { email?: string };
+
+    if (!body.email) {
+      return HttpResponse.json(
+        { message: "Email is required" },
+        { status: 400 },
+      );
+    }
+
+    // Always return 200 to avoid leaking whether an email exists
+    const token = `reset-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    resetTokens.set(token, body.email);
+
+    console.log(`[MSW] Password reset token for ${body.email}: ${token}`);
+
+    return HttpResponse.json({
+      message: "If an account with that email exists, a reset link has been sent.",
+    });
+  }),
+
+  // POST /api/auth/reset-password
+  http.post("/api/auth/reset-password", async ({ request }) => {
+    await delay(600);
+
+    const body = (await request.json()) as {
+      token?: string;
+      password?: string;
+    };
+
+    if (!body.token || !body.password) {
+      return HttpResponse.json(
+        { message: "Token and password are required" },
+        { status: 400 },
+      );
+    }
+
+    if (!resetTokens.has(body.token)) {
+      return HttpResponse.json(
+        { message: "Invalid or expired reset token" },
+        { status: 400 },
+      );
+    }
+
+    const email = resetTokens.get(body.token)!;
+
+    // Update the user's password in the in-memory store
+    const user = registeredUsers.find((u) => u.email === email);
+    if (user) {
+      user.password = body.password;
+    }
+
+    // Invalidate the token after use
+    resetTokens.delete(body.token);
+
+    return HttpResponse.json({
+      message: "Password has been reset successfully.",
     });
   }),
 ];

--- a/src/pages/forgetPasswordPage.tsx
+++ b/src/pages/forgetPasswordPage.tsx
@@ -3,10 +3,13 @@ import { ForgetPasswordForm } from "../components/auth/forgetPasswordForm";
 
 const ForgetPasswordPage = () => {
   return (
-    <AuthLayout>
+    <AuthLayout
+      title="Forgot Your Password?"
+      description="No worries! We'll send you a secure link to create a new password for your PetAd account."
+    >
       <ForgetPasswordForm />
     </AuthLayout>
   );
-}
+};
 
 export default ForgetPasswordPage;

--- a/src/pages/resetPasswordPage.tsx
+++ b/src/pages/resetPasswordPage.tsx
@@ -3,10 +3,13 @@ import { ResetPasswordForm } from "../components/auth/resetPasswordForm";
 
 const ResetPasswordPage = () => {
   return (
-    <AuthLayout>
+    <AuthLayout
+      title="Create a New Password"
+      description="Choose a strong password for your PetAd account. Make it unique and memorable."
+    >
       <ResetPasswordForm />
     </AuthLayout>
   );
-}
+};
 
-export default ResetPasswordPage
+export default ResetPasswordPage;

--- a/src/types/auth.tsx
+++ b/src/types/auth.tsx
@@ -18,3 +18,22 @@ export interface User {
   email: string;
   role: UserRole;
 }
+
+// ─── Password Reset ───────────────────────────────────────────────────────
+
+export interface PasswordResetRequestPayload {
+  email: string;
+}
+
+export interface PasswordResetPayload {
+  token: string;
+  password: string;
+}
+
+export interface PasswordResetRequestResponse {
+  message: string;
+}
+
+export interface PasswordResetResponse {
+  message: string;
+}


### PR DESCRIPTION
Add complete password reset flow including the forgot password request form with email-sent confirmation state, and a token-based reset password form with validation, API integration, and success modal. Wire up auth service methods, types, MSW handlers, and page wrappers with proper AuthLayout theming. Closes the password reset screens issue.

close #362 
