### PR TITLE
feat: add useMarkNotificationRead mutation hook

### DIFF
--- a/src/api/notificationService.ts
+++ b/src/api/notificationService.ts
@@ -1,0 +1,16 @@
+import { apiClient } from "../lib/api-client";
+
+/**
+ * notificationService
+ *
+ * Real notification API calls via the api-client.
+ */
+export const notificationService = {
+  /**
+   * Mark a single notification as read.
+   * PATCH /notifications/:id/read
+   */
+  async markAsRead(id: string | number): Promise<void> {
+    return apiClient.patch(`/notifications/${id}/read`);
+  },
+};

--- a/src/features/notifications/hooks/__tests__/useMarkNotificationRead.test.tsx
+++ b/src/features/notifications/hooks/__tests__/useMarkNotificationRead.test.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { notificationService } from "../../../../api/notificationService";
+import { useMarkNotificationRead } from "../useMarkNotificationRead";
+import type { Notification, NotificationsPage } from "../../../../types/notifications";
+
+vi.mock("../../../../api/notificationService", () => ({
+  notificationService: {
+    markAsRead: vi.fn(),
+  },
+}));
+
+const mockMarkAsRead = vi.mocked(notificationService.markAsRead);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { queryClient, wrapper };
+}
+
+const UNREAD_NOTIF: Notification = {
+  id: "notif-1",
+  type: "ESCROW_FUNDED",
+  title: "Escrow Funded",
+  message: "The escrow is ready.",
+  time: new Date().toISOString(),
+  isRead: false,
+};
+
+const READ_NOTIF: Notification = {
+  id: "notif-2",
+  type: "APPROVAL_REQUESTED",
+  title: "Approval Requested",
+  message: "A new approval request is waiting.",
+  time: new Date().toISOString(),
+  isRead: true,
+};
+
+function seedPaginatedCache(
+  queryClient: QueryClient,
+  notifications: Notification[],
+) {
+  queryClient.setQueryData(["notifications", "all"], {
+    pages: [{ data: notifications, nextCursor: null, total: notifications.length }],
+    pageParams: [undefined],
+  });
+}
+
+function seedDropdownCache(
+  queryClient: QueryClient,
+  notifications: Notification[],
+) {
+  queryClient.setQueryData<NotificationsPage>(["notifications", "dropdown"], {
+    data: notifications,
+    nextCursor: null,
+    total: notifications.length,
+  });
+}
+
+describe("useMarkNotificationRead", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("optimistically marks the notification as read before the API resolves", async () => {
+    let resolveRequest: (() => void) | undefined;
+    mockMarkAsRead.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+
+    const { queryClient, wrapper } = createWrapper();
+    seedPaginatedCache(queryClient, [UNREAD_NOTIF, READ_NOTIF]);
+    seedDropdownCache(queryClient, [UNREAD_NOTIF, READ_NOTIF]);
+
+    const { result } = renderHook(() => useMarkNotificationRead(), { wrapper });
+
+    act(() => {
+      result.current.markAsRead(UNREAD_NOTIF.id);
+    });
+
+    // While the request is in flight, the cache should already show isRead: true.
+    await waitFor(() => {
+      const paginated = queryClient.getQueryData<{
+        pages: NotificationsPage[];
+      }>(["notifications", "all"]);
+      const updated = paginated?.pages[0].data.find(
+        (n) => String(n.id) === String(UNREAD_NOTIF.id),
+      );
+      expect(updated?.isRead).toBe(true);
+    });
+
+    const dropdown = queryClient.getQueryData<NotificationsPage>([
+      "notifications",
+      "dropdown",
+    ]);
+    expect(
+      dropdown?.data.find((n) => String(n.id) === String(UNREAD_NOTIF.id))?.isRead,
+    ).toBe(true);
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith(UNREAD_NOTIF.id);
+
+    await act(async () => {
+      resolveRequest?.();
+    });
+  });
+
+  it("rolls back the read flag and surfaces an inline error when the API fails", async () => {
+    let rejectRequest: ((reason?: unknown) => void) | undefined;
+    mockMarkAsRead.mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRequest = reject;
+        }),
+    );
+
+    const { queryClient, wrapper } = createWrapper();
+    seedPaginatedCache(queryClient, [UNREAD_NOTIF, READ_NOTIF]);
+    seedDropdownCache(queryClient, [UNREAD_NOTIF, READ_NOTIF]);
+
+    const { result } = renderHook(() => useMarkNotificationRead(), { wrapper });
+
+    act(() => {
+      result.current.markAsRead(UNREAD_NOTIF.id);
+    });
+
+    // Confirm optimistic state was applied.
+    await waitFor(() => {
+      const paginated = queryClient.getQueryData<{
+        pages: NotificationsPage[];
+      }>(["notifications", "all"]);
+      const updated = paginated?.pages[0].data.find(
+        (n) => String(n.id) === String(UNREAD_NOTIF.id),
+      );
+      expect(updated?.isRead).toBe(true);
+    });
+
+    await act(async () => {
+      rejectRequest?.(new Error("network error"));
+    });
+
+    // Flag should be reverted and the error surfaced for inline display.
+    await waitFor(() => {
+      const paginated = queryClient.getQueryData<{
+        pages: NotificationsPage[];
+      }>(["notifications", "all"]);
+      const reverted = paginated?.pages[0].data.find(
+        (n) => String(n.id) === String(UNREAD_NOTIF.id),
+      );
+      expect(reverted?.isRead).toBe(false);
+    });
+
+    const dropdown = queryClient.getQueryData<NotificationsPage>([
+      "notifications",
+      "dropdown",
+    ]);
+    expect(
+      dropdown?.data.find((n) => String(n.id) === String(UNREAD_NOTIF.id))?.isRead,
+    ).toBe(false);
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).not.toBeNull();
+  });
+});

--- a/src/features/notifications/hooks/useMarkNotificationRead.ts
+++ b/src/features/notifications/hooks/useMarkNotificationRead.ts
@@ -1,0 +1,94 @@
+import { useQueryClient, type QueryKey } from "@tanstack/react-query";
+import { useApiMutation } from "../../../hooks/useApiMutation";
+import { notificationService } from "../../../api/notificationService";
+import type { NotificationsPage } from "../../../types/notifications";
+
+/**
+ * Cache shapes that hold notifications:
+ * - Paginated infinite-query caches, e.g. ["notifications", "all"]
+ * - Single-page caches, e.g. ["notifications", "dropdown"]
+ */
+type NotificationCacheEntry =
+  | { pages: NotificationsPage[]; pageParams: (string | undefined)[] }
+  | NotificationsPage;
+
+function setReadFlag(
+  cache: NotificationCacheEntry | undefined,
+  id: string | number,
+  isRead: boolean,
+): NotificationCacheEntry | undefined {
+  if (!cache) return cache;
+
+  if ("pages" in cache && Array.isArray(cache.pages)) {
+    return {
+      ...cache,
+      pages: cache.pages.map((page) => ({
+        ...page,
+        data: page.data.map((n) =>
+          String(n.id) === String(id) ? { ...n, isRead } : n,
+        ),
+      })),
+    };
+  }
+
+  if ("data" in cache && Array.isArray(cache.data)) {
+    return {
+      ...cache,
+      data: cache.data.map((n) =>
+        String(n.id) === String(id) ? { ...n, isRead } : n,
+      ),
+    };
+  }
+
+  return cache;
+}
+
+/**
+ * useMarkNotificationRead
+ *
+ * Marks a notification as read with an optimistic update:
+ *  1. Sets `isRead: true` in every notifications cache immediately.
+ *  2. Fires `notificationService.markAsRead(id)`.
+ *  3. On failure, reverts the local flag and surfaces a subtle inline
+ *     error via `error`/`isError` (callers render it inline, not as a
+ *     blocking toast).
+ */
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending, isError, error } = useApiMutation<
+    void,
+    string | number
+  >((id) => notificationService.markAsRead(id), {
+    invalidates: [["notifications"]],
+
+    onOptimisticUpdate: (id) => {
+      // Snapshot every notifications cache so we can restore it on failure.
+      const snapshot = queryClient.getQueriesData<NotificationCacheEntry>({
+        queryKey: ["notifications"],
+      });
+
+      queryClient.setQueriesData<NotificationCacheEntry>(
+        { queryKey: ["notifications"] },
+        (old) => setReadFlag(old, id, true),
+      );
+
+      return snapshot;
+    },
+
+    onRollback: (snapshot) => {
+      (snapshot as [QueryKey, NotificationCacheEntry | undefined][]).forEach(
+        ([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        },
+      );
+    },
+  });
+
+  return {
+    markAsRead: (id: string | number) => mutate(id),
+    isPending,
+    isError,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #471

Adds the `useMarkNotificationRead` mutation hook for marking a single notification as read, with a fully optimistic UX:

- **Optimistic update**: sets `isRead: true` in every cached notifications query (paginated list caches like `["notifications", "all"]` and the dropdown cache `["notifications", "dropdown"]`) **immediately** when `markAsRead(id)` is called — no waiting on the network.
- **Service call**: fires `notificationService.markAsRead(id)` (`PATCH /notifications/:id/read` via `apiClient`).
- **Rollback on failure**: if the request fails, the previous cache state is restored exactly (flag reverted to `isRead: false`).
- **Subtle inline error**: surfaces the failure through `error` / `isError` from the hook so callers can render a subtle inline message — it deliberately does **not** trigger a blocking toast.

## Files changed

- `src/features/notifications/hooks/useMarkNotificationRead.ts` — the new hook (new feature folder structure per issue)
- `src/api/notificationService.ts` — small service wrapper exposing `markAsRead(id)` (matches the `notificationService.markAsRead(id)` referenced in the issue; the codebase had no notification service yet)
- `src/features/notifications/hooks/__tests__/useMarkNotificationRead.test.tsx` — tests covering the acceptance criteria

## Acceptance criteria

- [x] Optimistic update covered by a test — verifies the cache flips to `isRead: true` before the API resolves, in both the paginated and dropdown caches, and that the service is called with the notification id.
- [x] Rollback covered by a test — rejects the API call and verifies the flag reverts to `isRead: false` in both caches and that `isError`/`error` are surfaced.

## Verification

- `tsc -b --noEmit` ✅
- `eslint` on changed files ✅
- New hook tests pass (2/2) ✅
- Existing notifications + mutation hook tests still pass (78 tests) ✅

## Notes

The existing `useMutateMarkRead` in `src/hooks/` applies an optimistic update but has no rollback and no error surfacing; this hook is the issue-specified replacement pattern (feature-scoped, rollback + inline error). No existing call sites were changed — consumers can migrate to this hook independently.