### PR TITLE
B2: Add Zod schema for the dispute submission form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "react-router-dom": "^7.13.1",
         "tailwindcss": "^4.2.0",
         "type-fest": "^5.6.0",
-        "undici": "^8.1.0"
+        "undici": "^8.1.0",
+        "zod": "^4.5.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -3380,6 +3381,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
@@ -6447,10 +6462,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
+      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^7.13.1",
     "tailwindcss": "^4.2.0",
     "type-fest": "^5.6.0",
-    "undici": "^8.1.0"
+    "undici": "^8.1.0",
+    "zod": "^4.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       undici:
         specifier: ^8.1.0
         version: 8.3.0
+      zod:
+        specifier: ^4.5.2
+        version: 4.5.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.1
@@ -2218,8 +2221,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
 snapshots:
 
@@ -3279,8 +3282,8 @@ snapshots:
       '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
+      zod: 4.5.2
+      zod-validation-error: 4.0.2(zod@4.5.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -4162,8 +4165,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.4.3):
+  zod-validation-error@4.0.2(zod@4.5.2):
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.2
 
-  zod@4.4.3: {}
+  zod@4.5.2: {}

--- a/src/features/disputes/schemas/__tests__/disputeSchemas.test.ts
+++ b/src/features/disputes/schemas/__tests__/disputeSchemas.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { disputeFormSchema } from '../disputeSchemas';
+
+const validDispute = {
+  reason: 'pet_condition',
+  description: 'The pet arrived with a health condition that was not disclosed in the adoption listing.',
+};
+
+describe('disputeFormSchema', () => {
+  it('accepts a valid dispute submission', () => {
+    const result = disputeFormSchema.safeParse(validDispute);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a description under 50 characters with the exact message', () => {
+    const result = disputeFormSchema.safeParse({
+      ...validDispute,
+      description: 'Too short',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        'Please provide more detail (at least 50 characters)',
+      );
+    }
+  });
+
+  it('accepts a description of exactly 50 characters', () => {
+    const result = disputeFormSchema.safeParse({
+      ...validDispute,
+      description: 'a'.repeat(50),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['pet_condition', 'custody_violation', 'payment_issue', 'other'])(
+    'accepts reason "%s"',
+    (reason) => {
+      const result = disputeFormSchema.safeParse({ ...validDispute, reason });
+      expect(result.success).toBe(true);
+    },
+  );
+
+  it('rejects an unknown reason', () => {
+    const result = disputeFormSchema.safeParse({
+      ...validDispute,
+      reason: 'unknown_reason',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a submission without attachmentIds', () => {
+    const result = disputeFormSchema.safeParse(validDispute);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts attachmentIds as an array of strings', () => {
+    const result = disputeFormSchema.safeParse({
+      ...validDispute,
+      attachmentIds: ['file-1', 'file-2'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-string entries in attachmentIds', () => {
+    const result = disputeFormSchema.safeParse({
+      ...validDispute,
+      attachmentIds: ['file-1', 42],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing reason', () => {
+    const result = disputeFormSchema.safeParse({ description: validDispute.description });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/disputes/schemas/disputeSchemas.ts
+++ b/src/features/disputes/schemas/disputeSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const disputeFormSchema = z.object({
+  reason: z.enum(['pet_condition', 'custody_violation', 'payment_issue', 'other']),
+  description: z.string().min(50, 'Please provide more detail (at least 50 characters)'),
+  attachmentIds: z.array(z.string()).optional(),
+});
+
+export type DisputeFormData = z.infer<typeof disputeFormSchema>;


### PR DESCRIPTION
## Summary

Adds a Zod validation schema for the dispute submission form, mirroring the pattern established by `adoptionFormSchema` in the README.

## Changes

- **`src/features/disputes/schemas/disputeSchemas.ts`** — new `disputeFormSchema` with:
  - `reason`: enum of `pet_condition`, `custody_violation`, `payment_issue`, `other`
  - `description`: string with a 50-character minimum and message `"Please provide more detail (at least 50 characters)"`
  - `attachmentIds`: optional array of strings
  - Exports `DisputeFormData` type via `z.infer`
- **`src/features/disputes/schemas/__tests__/disputeSchemas.test.ts`** — unit tests covering the acceptance criteria: rejects descriptions under 50 characters with the exact message, accepts exactly 50 characters, validates the reason enum, and handles optional/invalid `attachmentIds`
- **`package.json` + lockfiles** — adds `zod` (^4.5.2) as a dependency, since it wasn't installed yet

> Note: the issue referenced `src/features/dispute/`, but the repo's feature folder is `src/features/disputes/` (plural), so the schema lives there to match existing structure.

## Acceptance criteria

- [x] `disputeFormSchema.safeParse` rejects a description under 50 characters with the exact message above

## Verification

- `npm test` — 753 tests pass (12 new)
- `npx tsc -b` — clean
- `npm run lint` — clean

Closes #451