### PR TITLE
feat: implement realtime connection manager

### DIFF
--- a/src/lib/realtime/__tests__/notificationSocket.test.ts
+++ b/src/lib/realtime/__tests__/notificationSocket.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationSocket } from "../notificationSocket";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  private listeners: Record<string, Array<(event: Event | MessageEvent | CloseEvent) => void>>;
+
+  constructor(url: string) {
+    this.url = url;
+    this.readyState = MockWebSocket.CONNECTING;
+    this.listeners = {
+      open: [],
+      message: [],
+      error: [],
+      close: [],
+    };
+    MockWebSocket.instances.push(this);
+
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.dispatchEvent(new Event("open"));
+    });
+  }
+
+  addEventListener(event: string, handler: (event: Event | MessageEvent | CloseEvent) => void) {
+    this.listeners[event]?.push(handler);
+  }
+
+  removeEventListener(event: string, handler: (event: Event | MessageEvent | CloseEvent) => void) {
+    this.listeners[event] = this.listeners[event]?.filter((fn) => fn !== handler) ?? [];
+  }
+
+  dispatchEvent(event: Event | MessageEvent | CloseEvent) {
+    const listeners = this.listeners[event.type] ?? [];
+    listeners.forEach((handler) => handler(event));
+
+    if (event.type === "open" && this.onopen) this.onopen(event as Event);
+    if (event.type === "message" && this.onmessage) this.onmessage(event as MessageEvent);
+    if (event.type === "error" && this.onerror) this.onerror(event as Event);
+    if (event.type === "close" && this.onclose) this.onclose(event as CloseEvent);
+  }
+
+  send(data: string) {
+    void data;
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.dispatchEvent(new CloseEvent("close", { code: 1000, wasClean: true }));
+  }
+
+  triggerMessage(payload: unknown) {
+    this.dispatchEvent(new MessageEvent("message", {
+      data: typeof payload === "string" ? payload : JSON.stringify(payload),
+    }));
+  }
+
+  triggerClose() {
+    this.close();
+  }
+}
+
+describe("NotificationSocket", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("connects successfully and receives a message", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+
+    const socket = new NotificationSocket({
+      url: "ws://example.test/notifications",
+      WebSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+    });
+    const onMessage = vi.fn();
+
+    socket.on("message", onMessage);
+    socket.connect();
+
+    await Promise.resolve();
+
+    expect(socket.status).toBe("connected");
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    MockWebSocket.instances[0].triggerMessage({ type: "notification", id: "n-42" });
+
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "notification", id: "n-42" }),
+    );
+  });
+
+  it("does not duplicate a connection while already connected or connecting", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+
+    const socket = new NotificationSocket({
+      url: "ws://example.test/notifications",
+      WebSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    socket.connect();
+    socket.connect();
+    await Promise.resolve();
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(socket.status).toBe("connected");
+  });
+
+  it("reconnects after a manual disconnect and reconnect call", async () => {
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+
+    const socket = new NotificationSocket({
+      url: "ws://example.test/notifications",
+      WebSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    socket.connect();
+    await Promise.resolve();
+    socket.disconnect();
+
+    expect(socket.status).toBe("disconnected");
+
+    socket.connect();
+    await Promise.resolve();
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(socket.status).toBe("connected");
+  });
+
+  it("gives up after the configured max retries", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+
+    const socket = new NotificationSocket({
+      url: "ws://example.test/notifications",
+      WebSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+      maxRetries: 2,
+      initialRetryDelayMs: 100,
+      maxRetryDelayMs: 200,
+    });
+    const onGiveUp = vi.fn();
+
+    socket.on("giveup", onGiveUp);
+    socket.connect();
+    await Promise.resolve();
+
+    const first = MockWebSocket.instances[0];
+    first.triggerClose();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    const second = MockWebSocket.instances[1];
+    second.triggerClose();
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    const third = MockWebSocket.instances[2];
+    third.triggerClose();
+
+    expect(socket.status).toBe("failed");
+    expect(onGiveUp).toHaveBeenCalled();
+  });
+
+  it("reconnects again when the browser regains focus", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+
+    const socket = new NotificationSocket({
+      url: "ws://example.test/notifications",
+      WebSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+      initialRetryDelayMs: 100,
+      maxRetryDelayMs: 200,
+    });
+
+    socket.connect();
+    await Promise.resolve();
+
+    const first = MockWebSocket.instances[0];
+    first.triggerClose();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const second = MockWebSocket.instances[1];
+    expect(second).toBeDefined();
+    second.triggerClose();
+
+    window.dispatchEvent(new Event("focus"));
+    await Promise.resolve();
+
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    expect(socket.status).not.toBe("failed");
+  });
+});

--- a/src/lib/realtime/notificationSocket.ts
+++ b/src/lib/realtime/notificationSocket.ts
@@ -1,0 +1,211 @@
+export type NotificationSocketStatus =
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "failed";
+
+export type NotificationSocketEvent =
+  | "connect"
+  | "disconnect"
+  | "message"
+  | "error"
+  | "reconnect"
+  | "giveup";
+
+export interface NotificationSocketOptions {
+  url: string;
+  WebSocketCtor?: typeof WebSocket;
+  maxRetries?: number;
+  initialRetryDelayMs?: number;
+  maxRetryDelayMs?: number;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+}
+
+export interface NotificationMessage {
+  type?: string;
+  [key: string]: unknown;
+}
+
+export type NotificationSocketHandler<T = NotificationMessage> = (payload: T) => void;
+
+export class NotificationSocket {
+  private readonly url: string;
+  private readonly WebSocketCtor: typeof WebSocket;
+  private readonly maxRetries: number;
+  private readonly initialRetryDelayMs: number;
+  private readonly maxRetryDelayMs: number;
+  private readonly onConnect?: () => void;
+  private readonly onDisconnect?: () => void;
+
+  private socket: WebSocket | null = null;
+  private statusState: NotificationSocketStatus = "disconnected";
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private shouldReconnect = false;
+  private isManualDisconnect = false;
+  private handlers: Partial<Record<NotificationSocketEvent, Set<Function>>> = {};
+
+  constructor(options: NotificationSocketOptions) {
+    this.url = options.url;
+    this.WebSocketCtor = options.WebSocketCtor ?? WebSocket;
+    this.maxRetries = options.maxRetries ?? 5;
+    this.initialRetryDelayMs = options.initialRetryDelayMs ?? 1000;
+    this.maxRetryDelayMs = options.maxRetryDelayMs ?? 30000;
+    this.onConnect = options.onConnect;
+    this.onDisconnect = options.onDisconnect;
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", this.handleWindowFocus);
+    }
+  }
+
+  get status(): NotificationSocketStatus {
+    return this.statusState;
+  }
+
+  connect(): void {
+    if (this.socket && (this.statusState === "connecting" || this.statusState === "connected")) {
+      return;
+    }
+
+    if (this.statusState === "failed" || this.statusState === "disconnected" || this.isManualDisconnect) {
+      this.reconnectAttempts = 0;
+    }
+
+    this.isManualDisconnect = false;
+    this.shouldReconnect = true;
+    this.statusState = "connecting";
+    this.clearReconnectTimer();
+
+    try {
+      const ws = new this.WebSocketCtor(this.url);
+      this.socket = ws;
+      ws.onopen = () => {
+        this.statusState = "connected";
+        this.onConnect?.();
+        this.emit("connect");
+      };
+      ws.onmessage = (event: MessageEvent) => {
+        const payload = this.parseMessage(event.data);
+        this.emit("message", payload);
+      };
+      ws.onerror = () => {
+        this.statusState = this.statusState === "connected" ? "reconnecting" : this.statusState;
+        this.emit("error");
+      };
+      ws.onclose = () => {
+        this.socket = null;
+
+        if (this.isManualDisconnect) {
+          this.statusState = "disconnected";
+          this.emit("disconnect");
+          this.onDisconnect?.();
+          return;
+        }
+
+        this.handleConnectionLoss();
+      };
+    } catch {
+      this.handleConnectionLoss();
+    }
+  }
+
+  disconnect(): void {
+    this.isManualDisconnect = true;
+    this.shouldReconnect = false;
+    this.clearReconnectTimer();
+
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+
+    this.statusState = "disconnected";
+    this.emit("disconnect");
+    this.onDisconnect?.();
+  }
+
+  on<T = NotificationMessage>(event: NotificationSocketEvent, handler: NotificationSocketHandler<T>): void {
+    if (!this.handlers[event]) {
+      this.handlers[event] = new Set();
+    }
+
+    this.handlers[event]!.add(handler as Function);
+  }
+
+  private handleConnectionLoss(): void {
+    if (!this.shouldReconnect) {
+      this.statusState = "disconnected";
+      return;
+    }
+
+    this.statusState = "reconnecting";
+    this.reconnectAttempts += 1;
+
+    if (this.reconnectAttempts > this.maxRetries) {
+      this.statusState = "failed";
+      this.emit("giveup");
+      return;
+    }
+
+    const delay = this.getRetryDelay(this.reconnectAttempts);
+
+    this.reconnectTimer = setTimeout(() => {
+      this.emit("reconnect");
+      this.connect();
+    }, delay);
+  }
+
+  private handleWindowFocus = () => {
+    if (
+      this.statusState === "failed" ||
+      this.statusState === "disconnected" ||
+      (this.statusState === "reconnecting" && !this.socket)
+    ) {
+      this.connect();
+    }
+  };
+
+  private getRetryDelay(attempt: number): number {
+    const delay = this.initialRetryDelayMs * 2 ** (attempt - 1);
+    return Math.min(delay, this.maxRetryDelayMs);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private parseMessage(data: unknown): NotificationMessage {
+    if (typeof data === "string") {
+      try {
+        return JSON.parse(data) as NotificationMessage;
+      } catch {
+        return { raw: data };
+      }
+    }
+
+    if (data && typeof data === "object") {
+      return data as NotificationMessage;
+    }
+
+    return { raw: data };
+  }
+
+  private emit(event: NotificationSocketEvent, payload?: NotificationMessage): void {
+    const handlers = this.handlers[event];
+    if (!handlers) return;
+
+    for (const handler of handlers) {
+      if (payload !== undefined) {
+        handler(payload);
+      } else {
+        handler();
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the real-time connection manager in `src/lib/realtime/notificationSocket.ts`.

The manager provides a single connection lifecycle with automatic recovery and prevents duplicate WebSocket connections.

## Changes

* Added `connect()` and `disconnect()` lifecycle methods
* Added event subscription through `on(event, handler)`
* Added WebSocket message handling
* Added automatic reconnect with exponential backoff:

  * 1s
  * 2s
  * 4s
  * capped at 30s
* Added maximum retry handling and a give-up state for UI consumption
* Prevented duplicate connections when `connect()` is called while already connected or connecting
* Added tab foreground/focus recovery handling for browser timer throttling
* Ensured clean disconnection prevents unwanted reconnect attempts

## Tests

Added unit tests covering:

* Successful connection
* Message receipt
* Forced disconnect and automatic reconnect
* Duplicate `connect()` calls
* Exponential reconnect behavior
* Maximum retry / give-up state
* Tab focus recovery after backgrounding

Tests use a mocked WebSocket environment rather than a real server.

## Validation

```bash
npm test
npm run lint
npm run typecheck
```

Focused realtime connection tests were also executed.

## Design Tradeoffs

The connection manager owns the WebSocket lifecycle so consumers do not need to coordinate connection state or implement their own retry logic.

Exponential backoff is capped to prevent excessive reconnect attempts, while the give-up state allows the UI to surface a persistent connection failure.

## Limitations

Any pre-existing failures unrelated to the realtime connection manager are documented separately and were not modified as part of this issue.

closes #469
