### PR TITLE
Fix: B5. Add `useDisputeDetail` query hook (Auto-Generated)

### DIFF
--- a/src/hooks/useDisputeDetail.ts
+++ b/src/hooks/useDisputeDetail.ts
@@ -12,12 +12,24 @@ interface DisputeDetailApiResponse extends Omit<DisputeDetail, "resolution"> {
     txHash?: string;
     splitDistribution?: DisputeResolution["splitDistribution"];
   } | null;
+  comments?: Array<{
+    id: string;
+    authorName: string;
+    content: string;
+    createdAt: string;
+  }>;
 }
 
 export interface EnrichedDisputeDetail extends DisputeDetail {
   escrowOnChainStatus?: string;
   stellarExplorerUrl?: string;
   resolutionTxHash?: string;
+  comments?: Array<{
+    id: string;
+    authorName: string;
+    content: string;
+    createdAt: string;
+  }>;
 }
 
 function buildStellarExplorerUrl(accountId?: string | null): string {
@@ -29,7 +41,7 @@ export function useDisputeDetail(disputeId: string) {
   const query = useApiQuery<DisputeDetailApiResponse>(
     ["dispute-detail", disputeId],
     () => apiClient.get<DisputeDetailApiResponse>(`/disputes/${disputeId}`),
-    { enabled: Boolean(disputeId) },
+    { enabled: Boolean(disputeId), staleTime: 15000 },
   );
 
   const enrichedData = useMemo<EnrichedDisputeDetail | undefined>(() => {
@@ -39,7 +51,6 @@ export function useDisputeDetail(disputeId: string) {
 
     const raw = query.data;
 
-    // Map API resolution shape to our typed DisputeResolution
     let resolution: DisputeResolution | null = null;
     if (
       raw.resolution &&
@@ -64,6 +75,7 @@ export function useDisputeDetail(disputeId: string) {
       escrowOnChainStatus: raw.escrow?.status,
       stellarExplorerUrl: buildStellarExplorerUrl(raw.escrow?.accountId),
       resolutionTxHash: raw.resolution?.txHash,
+      comments: raw.comments ?? [],
     };
   }, [query.data]);
 


### PR DESCRIPTION
Closes #454

This pull request was generated automatically and scoped strictly to issue #454.

### Changes
Implemented useDisputeDetail query hook with comments support and optimized staleTime. Close #B5

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #454` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->