### PR TITLE
Add notification socket connection state indicators

### DIFF
--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { Bell } from "lucide-react";
 import { useNotificationCount } from "../../lib/hooks/useNotificationCount";
+import { useNotificationSocket } from "../../context/NotificationSocketContext";
+import type { NotificationConnectionState } from "../../context/NotificationSocketContext";
+
+const CONNECTION_INDICATOR_COLORS: Record<NotificationConnectionState, string> = {
+  connected: "bg-green-500",
+  reconnecting: "bg-amber-500",
+  disconnected: "bg-red-500",
+};
 
 export interface NotificationBellProps {
   onClick: () => void;
@@ -9,6 +17,7 @@ export interface NotificationBellProps {
 
 export function NotificationBell({ onClick, className }: NotificationBellProps) {
   const { count } = useNotificationCount();
+  const { connectionState } = useNotificationSocket();
   const prevCountRef = useRef<number | null>(null);
   const [bellAnimKey, setBellAnimKey] = useState(0);
 
@@ -24,7 +33,10 @@ export function NotificationBell({ onClick, className }: NotificationBellProps) 
   }, [count]);
 
   const badgeText = count > 9 ? "9+" : String(count);
-  const ariaLabel = `Notifications, ${count} unread`;
+  const indicatorColor = CONNECTION_INDICATOR_COLORS[connectionState];
+  const ariaLabel = connectionState === "connected"
+    ? `Notifications, ${count} unread`
+    : `Notifications, ${count} unread, connection ${connectionState}`;
 
   return (
     <button
@@ -41,6 +53,14 @@ export function NotificationBell({ onClick, className }: NotificationBellProps) 
       >
         <Bell size={20} strokeWidth={2} />
       </span>
+
+      {/* Connection state indicator dot */}
+      <span
+        data-testid="connection-indicator"
+        className={`absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-white ${indicatorColor} ${connectionState === "reconnecting" ? "animate-pulse" : ""}`}
+        aria-label={`Notification connection: ${connectionState}`}
+      />
+
       {count > 0 ? (
         <span
           data-testid="notification-bell-badge"

--- a/src/components/notifications/NotificationCentreDropdown.tsx
+++ b/src/components/notifications/NotificationCentreDropdown.tsx
@@ -13,6 +13,7 @@ import { NotificationItem } from "./index";
 import { useMutateMarkRead } from "../../hooks/useMutateMarkRead";
 import { useMutateMarkAllRead } from "../../hooks/useMutateMarkAllRead";
 import { notificationRouter } from "../../lib/notificationRouter";
+import { useNotificationSocket } from "../../context/NotificationSocketContext";
 import type { Notification, NotificationsPage } from "../../types/notifications";
 
 
@@ -64,6 +65,7 @@ export function NotificationCentreDropdown({
 
   const { markRead, isPending: isMarkingRead } = useMutateMarkRead();
   const { markAllRead, isPending: isMarkingAll } = useMutateMarkAllRead();
+  const { connectionState, reconnect } = useNotificationSocket();
 
 
   const { data, isLoading, isError } = useQuery<NotificationsPage>({
@@ -226,6 +228,39 @@ export function NotificationCentreDropdown({
               </button>
             )}
           </div>
+
+          {/* Connection state banner */}
+          {connectionState !== "connected" && (
+            <div
+              data-testid="connection-banner"
+              className={`px-4 py-2 text-xs font-medium flex items-center justify-between ${
+                connectionState === "reconnecting"
+                  ? "bg-amber-50 text-amber-700 border-b border-amber-100"
+                  : "bg-red-50 text-red-700 border-b border-red-100"
+              }`}
+            >
+              <span className="flex items-center gap-1.5">
+                <span
+                  className={`w-1.5 h-1.5 rounded-full ${
+                    connectionState === "reconnecting" ? "bg-amber-500 animate-pulse" : "bg-red-500"
+                  }`}
+                />
+                {connectionState === "reconnecting"
+                  ? "Reconnecting... notifications may be delayed"
+                  : "Disconnected — notifications paused"}
+              </span>
+              {connectionState === "disconnected" && (
+                <button
+                  type="button"
+                  data-testid="reconnect-button"
+                  onClick={reconnect}
+                  className="text-red-600 hover:text-red-800 underline font-semibold"
+                >
+                  Reconnect
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Body */}
           <div

--- a/src/components/notifications/__tests__/NotificationBell.test.tsx
+++ b/src/components/notifications/__tests__/NotificationBell.test.tsx
@@ -2,10 +2,22 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NotificationBell } from "../NotificationBell";
 import { useNotificationCount } from "../../../lib/hooks/useNotificationCount";
+import { NotificationSocketProvider } from "../../../context/NotificationSocketContext";
 
 vi.mock("../../../lib/hooks/useNotificationCount");
 
 const mockUseNotificationCount = vi.mocked(useNotificationCount);
+
+function renderWithProvider(
+  ui: React.ReactElement,
+  initialState: "connected" | "disconnected" | "reconnecting" = "connected",
+) {
+  return render(
+    <NotificationSocketProvider initialState={initialState} enabled={false}>
+      {ui}
+    </NotificationSocketProvider>,
+  );
+}
 
 describe("NotificationBell", () => {
   beforeEach(() => {
@@ -15,59 +27,88 @@ describe("NotificationBell", () => {
 
   it("calls onClick when pressed", () => {
     const onClick = vi.fn();
-    render(<NotificationBell onClick={onClick} />);
+    renderWithProvider(<NotificationBell onClick={onClick} />);
     fireEvent.click(screen.getByRole("button", { name: /notifications/i }));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it("shows badge with exact count when count is between 1 and 9", () => {
     mockUseNotificationCount.mockReturnValue({ count: 7, isLoading: false });
-    render(<NotificationBell onClick={vi.fn()} />);
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />);
     expect(screen.getByTestId("notification-bell-badge")).toHaveTextContent("7");
   });
 
   it('caps badge display at "9+" when count is 10 or more', () => {
     mockUseNotificationCount.mockReturnValue({ count: 10, isLoading: false });
-    const { rerender } = render(<NotificationBell onClick={vi.fn()} />);
+    const { rerender } = renderWithProvider(<NotificationBell onClick={vi.fn()} />);
     expect(screen.getByTestId("notification-bell-badge")).toHaveTextContent("9+");
 
     mockUseNotificationCount.mockReturnValue({ count: 42, isLoading: false });
-    rerender(<NotificationBell onClick={vi.fn()} />);
+    rerender(
+      <NotificationSocketProvider initialState="connected" enabled={false}>
+        <NotificationBell onClick={vi.fn()} />
+      </NotificationSocketProvider>,
+    );
     expect(screen.getByTestId("notification-bell-badge")).toHaveTextContent("9+");
   });
 
   it("hides badge when count is 0", () => {
-    render(<NotificationBell onClick={vi.fn()} />);
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />);
     expect(screen.queryByTestId("notification-bell-badge")).toBeNull();
   });
 
-  it('uses aria-label "Notifications, N unread"', () => {
+  it('uses aria-label "Notifications, N unread" when connected', () => {
     mockUseNotificationCount.mockReturnValue({ count: 1, isLoading: false });
-    const { rerender } = render(<NotificationBell onClick={vi.fn()} />);
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />);
     expect(screen.getByRole("button")).toHaveAttribute(
       "aria-label",
       "Notifications, 1 unread",
     );
+  });
 
-    mockUseNotificationCount.mockReturnValue({ count: 4, isLoading: false });
-    rerender(<NotificationBell onClick={vi.fn()} />);
+  it("includes connection state in aria-label when not connected", () => {
+    mockUseNotificationCount.mockReturnValue({ count: 1, isLoading: false });
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />, "reconnecting");
     expect(screen.getByRole("button")).toHaveAttribute(
       "aria-label",
-      "Notifications, 4 unread",
+      "Notifications, 1 unread, connection reconnecting",
     );
   });
 
   it("applies bell animation class when unread count increases", () => {
     mockUseNotificationCount.mockReturnValue({ count: 1, isLoading: false });
-    const { rerender } = render(<NotificationBell onClick={vi.fn()} />);
+    const { rerender } = renderWithProvider(<NotificationBell onClick={vi.fn()} />);
     expect(screen.getByTestId("notification-bell-icon-wrap").className).not.toContain(
       "animate-notification-bell",
     );
 
     mockUseNotificationCount.mockReturnValue({ count: 2, isLoading: false });
-    rerender(<NotificationBell onClick={vi.fn()} />);
+    rerender(
+      <NotificationSocketProvider initialState="connected" enabled={false}>
+        <NotificationBell onClick={vi.fn()} />
+      </NotificationSocketProvider>,
+    );
     expect(screen.getByTestId("notification-bell-icon-wrap").className).toContain(
       "animate-notification-bell",
     );
+  });
+
+  it("shows green indicator when connected", () => {
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />, "connected");
+    const indicator = screen.getByTestId("connection-indicator");
+    expect(indicator.className).toContain("bg-green-500");
+  });
+
+  it("shows amber pulsing indicator when reconnecting", () => {
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />, "reconnecting");
+    const indicator = screen.getByTestId("connection-indicator");
+    expect(indicator.className).toContain("bg-amber-500");
+    expect(indicator.className).toContain("animate-pulse");
+  });
+
+  it("shows red indicator when disconnected", () => {
+    renderWithProvider(<NotificationBell onClick={vi.fn()} />, "disconnected");
+    const indicator = screen.getByTestId("connection-indicator");
+    expect(indicator.className).toContain("bg-red-500");
   });
 });

--- a/src/components/notifications/__tests__/NotificationCentreDropdown.test.tsx
+++ b/src/components/notifications/__tests__/NotificationCentreDropdown.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NotificationCentreDropdown } from "../NotificationCentreDropdown";
+import { NotificationSocketProvider } from "../../../context/NotificationSocketContext";
 import type { Notification } from "../../../types/notifications";
 
 
@@ -78,17 +79,22 @@ const defaultQueryResult = {
 };
 
 
-function createWrapper() {
+function createWrapper(initialState: "connected" | "disconnected" | "reconnecting" = "connected") {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>{children}</MemoryRouter>
+      <NotificationSocketProvider initialState={initialState} enabled={false}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </NotificationSocketProvider>
     </QueryClientProvider>
   );
 }
 
-function renderDropdown(props: Partial<React.ComponentProps<typeof NotificationCentreDropdown>> = {}) {
-  return render(<NotificationCentreDropdown {...props} />, { wrapper: createWrapper() });
+function renderDropdown(
+  props: Partial<React.ComponentProps<typeof NotificationCentreDropdown>> = {},
+  initialState: "connected" | "disconnected" | "reconnecting" = "connected",
+) {
+  return render(<NotificationCentreDropdown {...props} />, { wrapper: createWrapper(initialState) });
 }
 
 
@@ -310,5 +316,42 @@ describe("NotificationCentreDropdown", () => {
 
     expect(mockMarkRead).toHaveBeenCalledWith("n1");
     expect(screen.queryByTestId("notification-dropdown")).toBeNull();
+  });
+
+
+  // ── Connection state banner ──────────────────────────────────────────────
+  it("does not show connection banner when connected", () => {
+    renderDropdown({}, "connected");
+    fireEvent.click(screen.getByTestId("bell-button"));
+    expect(screen.queryByTestId("connection-banner")).not.toBeInTheDocument();
+  });
+
+  it("shows reconnecting banner when reconnecting", () => {
+    renderDropdown({}, "reconnecting");
+    fireEvent.click(screen.getByTestId("bell-button"));
+    const banner = screen.getByTestId("connection-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toContain("Reconnecting");
+    expect(banner.textContent).toContain("may be delayed");
+  });
+
+  it("shows disconnected banner when disconnected", () => {
+    renderDropdown({}, "disconnected");
+    fireEvent.click(screen.getByTestId("bell-button"));
+    const banner = screen.getByTestId("connection-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toContain("Disconnected");
+  });
+
+  it("shows reconnect button only when disconnected", () => {
+    renderDropdown({}, "disconnected");
+    fireEvent.click(screen.getByTestId("bell-button"));
+    expect(screen.getByTestId("reconnect-button")).toBeInTheDocument();
+  });
+
+  it("does not show reconnect button when reconnecting", () => {
+    renderDropdown({}, "reconnecting");
+    fireEvent.click(screen.getByTestId("bell-button"));
+    expect(screen.queryByTestId("reconnect-button")).not.toBeInTheDocument();
   });
 });

--- a/src/context/NotificationSocketContext.tsx
+++ b/src/context/NotificationSocketContext.tsx
@@ -1,0 +1,181 @@
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react";
+
+/**
+ * Connection states for the notification WebSocket:
+ * - connected: WebSocket is open and receiving messages
+ * - disconnected: WebSocket is closed and not attempting to reconnect
+ * - reconnecting: WebSocket is closed but attempting to reconnect (with backoff)
+ */
+export type NotificationConnectionState = "connected" | "disconnected" | "reconnecting";
+
+export interface NotificationSocketContextValue {
+  /** Current connection state */
+  connectionState: NotificationConnectionState;
+  /** Number of consecutive reconnect attempts */
+  reconnectAttempts: number;
+  /** Timestamp of last successful connection, or null */
+  lastConnectedAt: number | null;
+  /** Manually trigger a reconnection attempt */
+  reconnect: () => void;
+}
+
+const NotificationSocketContext = createContext<NotificationSocketContextValue | null>(null);
+
+const RECONNECT_BASE_DELAY = 1000;
+const RECONNECT_MAX_DELAY = 30000;
+
+function getReconnectDelay(attempt: number): number {
+  const delay = Math.min(RECONNECT_BASE_DELAY * Math.pow(2, attempt), RECONNECT_MAX_DELAY);
+  const jitter = Math.random() * delay * 0.1;
+  return delay + jitter;
+}
+
+export interface NotificationSocketProviderProps {
+  children: ReactNode;
+  /** Override for testing: simulate a specific initial state */
+  initialState?: NotificationConnectionState;
+  /** Override for testing: whether to actually attempt WebSocket connections */
+  enabled?: boolean;
+}
+
+export function NotificationSocketProvider({
+  children,
+  initialState = "disconnected",
+  enabled = true,
+}: NotificationSocketProviderProps) {
+  const [connectionState, setConnectionState] = useState<NotificationConnectionState>(initialState);
+  const [reconnectAttempts, setReconnectAttempts] = useState(0);
+  const [lastConnectedAt, setLastConnectedAt] = useState<number | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (!enabled || !mountedRef.current) return;
+
+    const token = (() => {
+      try {
+        return localStorage.getItem("auth_token") ?? sessionStorage.getItem("auth_token");
+      } catch {
+        return null;
+      }
+    })();
+
+    if (!token) {
+      setConnectionState("disconnected");
+      return;
+    }
+
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${protocol}//${window.location.host}/api/ws/notifications?token=${encodeURIComponent(token)}`;
+
+    try {
+      const ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (!mountedRef.current) return;
+        setConnectionState("connected");
+        setReconnectAttempts(0);
+        setLastConnectedAt(Date.now());
+      };
+
+      ws.onclose = (event) => {
+        if (!mountedRef.current) return;
+        wsRef.current = null;
+
+        // Code 4001 = Unauthorized — don't reconnect
+        if (event.code === 4001) {
+          setConnectionState("disconnected");
+          return;
+        }
+
+        // Normal close (code 1000) — don't reconnect
+        if (event.code === 1000) {
+          setConnectionState("disconnected");
+          return;
+        }
+
+        // Abnormal close — attempt reconnection
+        setConnectionState("reconnecting");
+        setReconnectAttempts((prev) => {
+          const next = prev + 1;
+          const delay = getReconnectDelay(next);
+          reconnectTimerRef.current = setTimeout(() => {
+            connect();
+          }, delay);
+          return next;
+        });
+      };
+
+      ws.onerror = () => {
+        // onerror is always followed by onclose, so we don't need to handle it separately
+      };
+    } catch {
+      setConnectionState("reconnecting");
+      setReconnectAttempts((prev) => {
+        const next = prev + 1;
+        const delay = getReconnectDelay(next);
+        reconnectTimerRef.current = setTimeout(() => {
+          connect();
+        }, delay);
+        return next;
+      });
+    }
+  }, [enabled]);
+
+  const reconnect = useCallback(() => {
+    cleanup();
+    setReconnectAttempts(0);
+    setConnectionState("reconnecting");
+    // Small delay before attempting to reconnect
+    reconnectTimerRef.current = setTimeout(() => {
+      connect();
+    }, 100);
+  }, [cleanup, connect]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    connect();
+    return () => {
+      mountedRef.current = false;
+      cleanup();
+    };
+  }, [connect, cleanup]);
+
+  const value: NotificationSocketContextValue = {
+    connectionState,
+    reconnectAttempts,
+    lastConnectedAt,
+    reconnect,
+  };
+
+  return (
+    <NotificationSocketContext.Provider value={value}>
+      {children}
+    </NotificationSocketContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the notification socket connection state.
+ * Must be used within a NotificationSocketProvider.
+ */
+export function useNotificationSocket(): NotificationSocketContextValue {
+  const context = useContext(NotificationSocketContext);
+  if (!context) {
+    throw new Error("useNotificationSocket must be used within a NotificationSocketProvider");
+  }
+  return context;
+}

--- a/src/context/__tests__/NotificationSocketContext.test.tsx
+++ b/src/context/__tests__/NotificationSocketContext.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  NotificationSocketProvider,
+  useNotificationSocket,
+} from "../NotificationSocketContext";
+
+// Mock WebSocket
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  readyState = 0;
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    this.readyState = 1; // OPEN
+    MockWebSocket.instances.push(this);
+  }
+
+  close(code = 1000) {
+    this.readyState = 3; // CLOSED
+    this.onclose?.({ code });
+  }
+
+  simulateOpen() {
+    this.onopen?.();
+  }
+
+  simulateClose(code = 1000) {
+    this.onclose?.({ code });
+  }
+}
+
+// Helper component to read context values
+function ConnectionReader() {
+  const { connectionState, reconnectAttempts, reconnect } = useNotificationSocket();
+  return (
+    <div>
+      <span data-testid="state">{connectionState}</span>
+      <span data-testid="attempts">{reconnectAttempts}</span>
+      <button data-testid="reconnect" onClick={reconnect}>
+        Reconnect
+      </button>
+    </div>
+  );
+}
+
+describe("NotificationSocketContext", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    // Set a fake auth token
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => (key === "auth_token" ? "test-token" : null)),
+      setItem: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts in disconnected state when no token is available", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+    });
+
+    render(
+      <NotificationSocketProvider>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    expect(screen.getByTestId("state")).toHaveTextContent("disconnected");
+  });
+
+  it("starts in the provided initial state for testing", () => {
+    render(
+      <NotificationSocketProvider initialState="connected">
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    expect(screen.getByTestId("state")).toHaveTextContent("connected");
+  });
+
+  it("shows reconnecting state when WebSocket closes abnormally", () => {
+    render(
+      <NotificationSocketProvider>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    // Simulate abnormal close
+    act(() => {
+      const ws = MockWebSocket.instances[0];
+      ws?.simulateClose(1006); // Abnormal closure
+    });
+
+    expect(screen.getByTestId("state")).toHaveTextContent("reconnecting");
+  });
+
+  it("shows disconnected state when WebSocket closes normally", () => {
+    render(
+      <NotificationSocketProvider>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    // Simulate normal close
+    act(() => {
+      const ws = MockWebSocket.instances[0];
+      ws?.simulateClose(1000); // Normal closure
+    });
+
+    expect(screen.getByTestId("state")).toHaveTextContent("disconnected");
+  });
+
+  it("shows disconnected state when unauthorized (code 4001)", () => {
+    render(
+      <NotificationSocketProvider>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    // Simulate unauthorized close
+    act(() => {
+      const ws = MockWebSocket.instances[0];
+      ws?.simulateClose(4001);
+    });
+
+    expect(screen.getByTestId("state")).toHaveTextContent("disconnected");
+  });
+
+  it("reconnect button resets state and attempts reconnection", () => {
+    render(
+      <NotificationSocketProvider>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    // First connect
+    act(() => {
+      MockWebSocket.instances[0]?.simulateOpen();
+    });
+    expect(screen.getByTestId("state")).toHaveTextContent("connected");
+
+    // Simulate abnormal close
+    act(() => {
+      MockWebSocket.instances[0]?.simulateClose(1006);
+    });
+    expect(screen.getByTestId("state")).toHaveTextContent("reconnecting");
+
+    // Click reconnect
+    act(() => {
+      screen.getByTestId("reconnect").click();
+    });
+
+    expect(screen.getByTestId("state")).toHaveTextContent("reconnecting");
+    expect(screen.getByTestId("attempts")).toHaveTextContent("0");
+  });
+
+  it("throws when used outside provider", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function BadComponent() {
+      useNotificationSocket();
+      return null;
+    }
+
+    expect(() => render(<BadComponent />)).toThrow(
+      "useNotificationSocket must be used within a NotificationSocketProvider",
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("does not attempt connection when enabled is false", () => {
+    render(
+      <NotificationSocketProvider enabled={false}>
+        <ConnectionReader />
+      </NotificationSocketProvider>,
+    );
+
+    // Should stay disconnected since connection is disabled
+    expect(screen.getByTestId("state")).toHaveTextContent("disconnected");
+    // No WebSocket instances should have been created
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+});

--- a/src/pages/__tests__/NotificationsListPage.test.tsx
+++ b/src/pages/__tests__/NotificationsListPage.test.tsx
@@ -20,6 +20,15 @@ vi.mock("../../hooks/useNotifications", () => ({
   useNotifications: vi.fn(),
 }));
 
+vi.mock("../../context/NotificationSocketContext", () => ({
+  useNotificationSocket: () => ({
+    connectionState: "connected",
+    reconnectAttempts: 0,
+    lastConnectedAt: Date.now(),
+    reconnect: vi.fn(),
+  }),
+}));
+
 vi.mock("../../components/notifications", () => ({
   NotificationItem: ({
     notification,

--- a/src/pages/notificationPage.tsx
+++ b/src/pages/notificationPage.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useMemo, useState } from "react";
 import { useNotifications } from "../hooks/useNotifications";
 import { NotificationItem } from "../components/notifications";
 import { EmptyState } from "../components/ui/emptyState";
+import { useNotificationSocket } from "../context/NotificationSocketContext";
 import type { Notification, NotificationFilter } from "../types/notifications";
 
 
@@ -98,6 +99,8 @@ export default function NotificationsListPage() {
     markRead,
   } = useNotifications(filter);
 
+  const { connectionState, reconnect } = useNotificationSocket();
+
   const unreadCount = useMemo(
     () => notifications.filter((n) => !n.isRead).length,
     [notifications],
@@ -147,6 +150,39 @@ export default function NotificationsListPage() {
           </span>
         )}
       </div>
+
+      {/* Connection state banner */}
+      {connectionState !== "connected" && (
+        <div
+          data-testid="connection-banner"
+          className={`mb-4 px-4 py-3 rounded-lg flex items-center justify-between ${
+            connectionState === "reconnecting"
+              ? "bg-amber-50 border border-amber-200 text-amber-700"
+              : "bg-red-50 border border-red-200 text-red-700"
+          }`}
+        >
+          <span className="flex items-center gap-2 text-sm">
+            <span
+              className={`w-2 h-2 rounded-full ${
+                connectionState === "reconnecting" ? "bg-amber-500 animate-pulse" : "bg-red-500"
+              }`}
+            />
+            {connectionState === "reconnecting"
+              ? "Reconnecting to notification service..."
+              : "Disconnected from notification service"}
+          </span>
+          {connectionState === "disconnected" && (
+            <button
+              type="button"
+              data-testid="reconnect-button"
+              onClick={reconnect}
+              className="text-sm font-medium text-red-600 hover:text-red-800 underline"
+            >
+              Reconnect
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Filter tabs */}
       <div


### PR DESCRIPTION
Closes #477

## Problem Statement
When the notification WebSocket disconnects, users have no indication that notifications may be delayed or paused. There was no visual feedback for the connection state, leading to confusion when real-time notifications stopped arriving.

## Solution
Created a `NotificationSocketProvider` context that tracks WebSocket connection state and exposes it to notification components. Each component shows appropriate indicators:

| Component | Connected | Reconnecting | Disconnected |
|-----------|-----------|--------------|--------------|
| NotificationBell | Green dot | Amber pulsing dot | Red dot |
| Dropdown | No banner | Amber "Reconnecting" banner | Red "Disconnected" banner with Reconnect button |
| NotificationsPage | No banner | Amber banner | Red banner with Reconnect button |

## Changes

| File | Change |
|------|--------|
| `NotificationSocketContext.tsx` | New context provider with WebSocket lifecycle management, exponential backoff reconnection (1s-30s with jitter), and `enabled` prop for testing |
| `NotificationBell.tsx` | Added color-coded connection indicator dot; aria-label includes connection state when not connected |
| `NotificationCentreDropdown.tsx` | Added connection state banner below header with reconnect button for disconnected state |
| `notificationPage.tsx` | Added connection state banner with reconnect button for disconnected state |
| Tests | 8 context tests, 10 bell tests (3 new), 5 dropdown tests (5 new) |

## Acceptance Criteria Met
- Forcing C4 into a disconnected state shows the "reconnecting" indicator within one render (verified by test: `shows reconnecting banner when reconnecting`)
- Bell shows amber pulsing dot when reconnecting
- Dropdown shows "Reconnecting... notifications may be delayed" banner
- Page shows "Disconnected from notification service" with Reconnect button

## Testing
- All 112 notification-related tests pass (6 test files)
- Context tests verify state transitions for connected/reconnecting/disconnected
- Component tests verify correct indicator rendering for each state